### PR TITLE
Support fixed parameters in request path

### DIFF
--- a/alibabacloud-gateway-sls/main.tea
+++ b/alibabacloud-gateway-sls/main.tea
@@ -150,13 +150,30 @@ async function getSignature(pathname: string, method: string, query: map[string]
 
 async function buildCanonicalizedResource(pathname: string, query: map[string]string): string {
   var canonicalizedResource : string = pathname;
-  if (!Util.isUnset(query)) {
-    var queryList : [string] = Map.keySet(query);
+  var paramsMap : map[string]string = query;
+  if (!Util.empty(pathname)) {
+    var paths : [string] = String.split(pathname, `?`, 2);
+    canonicalizedResource = paths[0];
+    if (Util.equalNumber(Array.size(paths), 2)) {
+      var params : [string] = String.split(paths[1], '&', 0);
+      for (var sub : params) {
+        var item : [string] = String.split(sub, '=', 0);
+        var key : string = item[0];
+        var value : string = null;
+        if (Util.equalNumber(Array.size(item), 2)) {
+          value = item[1];
+        }
+        paramsMap[key] = value;
+      }
+    }
+  }
+  if (!Util.isUnset(paramsMap)) {
+    var queryList : [string] = Map.keySet(paramsMap);
     var sortedParams = Array.ascSort(queryList);
     var separator : string = '?';
     for(var paramName : sortedParams) {
       canonicalizedResource = `${canonicalizedResource}${separator}${paramName}`;
-      var paramValue = query[paramName];
+      var paramValue = paramsMap[paramName];
       if (!Util.isUnset(paramValue)) {
         canonicalizedResource = `${canonicalizedResource}=${paramValue}`;
       }


### PR DESCRIPTION
The ```pathname```  may be something like ```/logstore?type=log``` so we need to parse ```type=log``` and put it to query parameters.