### PR TITLE
fix(gateway-oss): add missing dot in IPv6 dual-stack endpoint

### DIFF
--- a/alibabacloud-gateway-oss/csharp/core/Client.cs
+++ b/alibabacloud-gateway-oss/csharp/core/Client.cs
@@ -594,7 +594,7 @@ namespace AlibabaCloud.GatewayOss
                 }
                 else if (AlibabaCloud.DarabonbaString.StringUtil.Contains(network, "ipv6"))
                 {
-                    return "" + regionId + "oss.aliyuncs.com";
+                    return "" + regionId + ".oss.aliyuncs.com";
                 }
                 else if (AlibabaCloud.DarabonbaString.StringUtil.Contains(network, "accelerate"))
                 {
@@ -622,7 +622,7 @@ namespace AlibabaCloud.GatewayOss
                 }
                 else if (AlibabaCloud.DarabonbaString.StringUtil.Contains(network, "ipv6"))
                 {
-                    return "" + regionId + "oss.aliyuncs.com";
+                    return "" + regionId + ".oss.aliyuncs.com";
                 }
                 else if (AlibabaCloud.DarabonbaString.StringUtil.Contains(network, "accelerate"))
                 {

--- a/alibabacloud-gateway-oss/golang/client/client.go
+++ b/alibabacloud-gateway-oss/golang/client/client.go
@@ -410,7 +410,7 @@ func (client *Client) GetEndpoint(regionId *string, network *string, endpoint *s
 			_result = tea.String("oss-" + tea.StringValue(regionId) + "-internal.aliyuncs.com")
 			return _result, _err
 		} else if tea.BoolValue(string_.Contains(network, tea.String("ipv6"))) {
-			_result = tea.String(tea.StringValue(regionId) + "oss.aliyuncs.com")
+			_result = tea.String(tea.StringValue(regionId) + ".oss.aliyuncs.com")
 			return _result, _err
 		} else if tea.BoolValue(string_.Contains(network, tea.String("accelerate"))) {
 			_result = tea.String("oss-" + tea.StringValue(network) + ".aliyuncs.com")

--- a/alibabacloud-gateway-oss/java/pom.xml
+++ b/alibabacloud-gateway-oss/java/pom.xml
@@ -121,6 +121,12 @@
       <artifactId>alibabacloud-gateway-oss-util</artifactId>
       <version>0.0.13</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/alibabacloud-gateway-oss/java/src/main/java/com/aliyun/gateway/oss/Client.java
+++ b/alibabacloud-gateway-oss/java/src/main/java/com/aliyun/gateway/oss/Client.java
@@ -388,7 +388,7 @@ public class Client extends com.aliyun.gateway.spi.Client {
             if (com.aliyun.darabonbastring.Client.contains(network, "internal")) {
                 return "oss-" + regionId + "-internal.aliyuncs.com";
             } else if (com.aliyun.darabonbastring.Client.contains(network, "ipv6")) {
-                return "" + regionId + "oss.aliyuncs.com";
+                return "" + regionId + ".oss.aliyuncs.com";
             } else if (com.aliyun.darabonbastring.Client.contains(network, "accelerate")) {
                 return "oss-" + network + ".aliyuncs.com";
             }

--- a/alibabacloud-gateway-oss/java/src/test/java/com/aliyun/gateway/oss/UnitTest.java
+++ b/alibabacloud-gateway-oss/java/src/test/java/com/aliyun/gateway/oss/UnitTest.java
@@ -1,0 +1,41 @@
+package com.aliyun.gateway.oss;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UnitTest {
+
+    @Test
+    public void getEndpointTest() throws Exception {
+        Client client = new Client();
+
+        Assert.assertEquals("custom.endpoint.com",
+            client.getEndpoint("cn-hangzhou", null, "custom.endpoint.com"));
+        Assert.assertEquals("custom.endpoint.com",
+            client.getEndpoint("cn-hangzhou", "ipv6", "custom.endpoint.com"));
+
+        Assert.assertEquals("oss-cn-shanghai.aliyuncs.com",
+            client.getEndpoint("cn-shanghai", null, null));
+        Assert.assertEquals("oss-cn-hangzhou.aliyuncs.com",
+            client.getEndpoint(null, null, null));
+        Assert.assertEquals("oss-cn-hangzhou.aliyuncs.com",
+            client.getEndpoint("", "", ""));
+
+        Assert.assertEquals("oss-cn-hangzhou-internal.aliyuncs.com",
+            client.getEndpoint("cn-hangzhou", "internal", null));
+        Assert.assertEquals("oss-cn-beijing-internal.aliyuncs.com",
+            client.getEndpoint("cn-beijing", "vpc-internal", null));
+
+        Assert.assertEquals("cn-hangzhou.oss.aliyuncs.com",
+            client.getEndpoint("cn-hangzhou", "ipv6", null));
+        Assert.assertEquals("cn-shanghai.oss.aliyuncs.com",
+            client.getEndpoint("cn-shanghai", "dualstack-ipv6", null));
+        Assert.assertEquals("cn-hangzhou.oss.aliyuncs.com",
+            client.getEndpoint(null, "ipv6", null));
+
+        Assert.assertEquals("oss-accelerate.aliyuncs.com",
+            client.getEndpoint("cn-hangzhou", "accelerate", null));
+        Assert.assertEquals("oss-accelerate-overseas.aliyuncs.com",
+            client.getEndpoint("ap-southeast-1", "accelerate-overseas", null));
+    }
+}

--- a/alibabacloud-gateway-oss/main.tea
+++ b/alibabacloud-gateway-oss/main.tea
@@ -278,7 +278,7 @@ async function getEndpoint(regionId: string, network: string, endpoint: string) 
     if (String.contains(network, 'internal')) {
       return `oss-${regionId}-internal.aliyuncs.com`;
     } else if (String.contains(network, 'ipv6')) {
-      return `${regionId}oss.aliyuncs.com`;
+      return `${regionId}.oss.aliyuncs.com`;
     } else if (String.contains(network, 'accelerate')) {
       return `oss-${network}.aliyuncs.com`;
     }

--- a/alibabacloud-gateway-oss/php/src/Client.php
+++ b/alibabacloud-gateway-oss/php/src/Client.php
@@ -336,7 +336,7 @@ class Client extends DarabonbaGatewaySpiClient {
                 return "oss-" . $regionId . "-internal.aliyuncs.com";
             }
             else if (StringUtil::contains($network, "ipv6")) {
-                return "" . $regionId . "oss.aliyuncs.com";
+                return "" . $regionId . ".oss.aliyuncs.com";
             }
             else if (StringUtil::contains($network, "accelerate")) {
                 return "oss-" . $network . ".aliyuncs.com";

--- a/alibabacloud-gateway-oss/python/alibabacloud_gateway_oss/client.py
+++ b/alibabacloud-gateway-oss/python/alibabacloud_gateway_oss/client.py
@@ -546,7 +546,7 @@ class Client(SPIClient):
             if StringClient.contains(network, 'internal'):
                 return f'oss-{region_id}-internal.aliyuncs.com'
             elif StringClient.contains(network, 'ipv6'):
-                return f'{region_id}oss.aliyuncs.com'
+                return f'{region_id}.oss.aliyuncs.com'
             elif StringClient.contains(network, 'accelerate'):
                 return f'oss-{network}.aliyuncs.com'
         return f'oss-{region_id}.aliyuncs.com'
@@ -565,7 +565,7 @@ class Client(SPIClient):
             if StringClient.contains(network, 'internal'):
                 return f'oss-{region_id}-internal.aliyuncs.com'
             elif StringClient.contains(network, 'ipv6'):
-                return f'{region_id}oss.aliyuncs.com'
+                return f'{region_id}.oss.aliyuncs.com'
             elif StringClient.contains(network, 'accelerate'):
                 return f'oss-{network}.aliyuncs.com'
         return f'oss-{region_id}.aliyuncs.com'

--- a/alibabacloud-gateway-oss/python2/alibabacloud_gateway_oss/client.py
+++ b/alibabacloud-gateway-oss/python2/alibabacloud_gateway_oss/client.py
@@ -272,7 +272,7 @@ class Client(SPIClient):
             if StringClient.contains(network, 'internal'):
                 return 'oss-%s-internal.aliyuncs.com' % TeaConverter.to_unicode(region_id)
             elif StringClient.contains(network, 'ipv6'):
-                return '%soss.aliyuncs.com' % TeaConverter.to_unicode(region_id)
+                return '%s.oss.aliyuncs.com' % TeaConverter.to_unicode(region_id)
             elif StringClient.contains(network, 'accelerate'):
                 return 'oss-%s.aliyuncs.com' % TeaConverter.to_unicode(network)
         return 'oss-%s.aliyuncs.com' % TeaConverter.to_unicode(region_id)

--- a/alibabacloud-gateway-oss/ts/src/client.ts
+++ b/alibabacloud-gateway-oss/ts/src/client.ts
@@ -352,7 +352,7 @@ export default class Client extends SPI {
       if (String.contains(network, "internal")) {
         return `oss-${regionId}-internal.aliyuncs.com`;
       } else if (String.contains(network, "ipv6")) {
-        return `${regionId}oss.aliyuncs.com`;
+        return `${regionId}.oss.aliyuncs.com`;
       } else if (String.contains(network, "accelerate")) {
         return `oss-${network}.aliyuncs.com`;
       }


### PR DESCRIPTION
## Summary

- Fix `getEndpoint()` IPv6/dual-stack host: `${regionId}.oss.aliyuncs.com` (was missing `.`, e.g. `cn-hangzhouoss.aliyuncs.com`).
- Sync the one-line fix across Java / Go / TS / Python / Python2 / PHP / C# generated clients from `main.tea`.
- Add Java unit tests covering default / internal / ipv6 / accelerate endpoint branches.