### PR TITLE
fix(gateway-pds): DownloadFile content-type on wire matches signature

### DIFF
--- a/alibabacloud-gateway-pds/csharp/core/Client.cs
+++ b/alibabacloud-gateway-pds/csharp/core/Client.cs
@@ -125,12 +125,8 @@ namespace AlibabaCloud.GatewayPds
                     }
                     else if (AlibabaCloud.DarabonbaString.StringUtil.Equals(request.ReqBodyType, "formData") && AlibabaCloud.DarabonbaString.StringUtil.Equals(request.Action, "DownloadFile") && AlibabaCloud.DarabonbaString.StringUtil.Equals(request.Pathname, "/v2/file/download"))
                     {
-                        List<string> headersArray = AlibabaCloud.DarabonbaMap.MapUtil.KeySet(request.Headers);
-
-                        foreach (var key in headersArray) {
-                            headers[key] = request.Headers.Get(key);
-                        }
-                        headers["content-type"] = "application/x-www-form-urlencoded; charset=UTF-8";
+                        request.Headers["content-type"] = "application/x-www-form-urlencoded; charset=UTF-8";
+                        headers = request.Headers;
                     }
                     else
                     {
@@ -244,12 +240,8 @@ namespace AlibabaCloud.GatewayPds
                     }
                     else if (AlibabaCloud.DarabonbaString.StringUtil.Equals(request.ReqBodyType, "formData") && AlibabaCloud.DarabonbaString.StringUtil.Equals(request.Action, "DownloadFile") && AlibabaCloud.DarabonbaString.StringUtil.Equals(request.Pathname, "/v2/file/download"))
                     {
-                        List<string> headersArray = AlibabaCloud.DarabonbaMap.MapUtil.KeySet(request.Headers);
-
-                        foreach (var key in headersArray) {
-                            headers[key] = request.Headers.Get(key);
-                        }
-                        headers["content-type"] = "application/x-www-form-urlencoded; charset=UTF-8";
+                        request.Headers["content-type"] = "application/x-www-form-urlencoded; charset=UTF-8";
+                        headers = request.Headers;
                     }
                     else
                     {

--- a/alibabacloud-gateway-pds/golang/client/client.go
+++ b/alibabacloud-gateway-pds/golang/client/client.go
@@ -125,11 +125,8 @@ func (client *Client) ModifyRequest(context *spi.InterceptorContext, attributeMa
 			if !tea.BoolValue(util.IsUnset(request.Headers["content-type"])) {
 				headers = request.Headers
 			} else if tea.BoolValue(string_.Equals(request.ReqBodyType, tea.String("formData"))) && tea.BoolValue(string_.Equals(request.Action, tea.String("DownloadFile"))) && tea.BoolValue(string_.Equals(request.Pathname, tea.String("/v2/file/download"))) {
-				headersArray := map_.KeySet(request.Headers)
-				for _, key := range headersArray {
-					headers[tea.StringValue(key)] = request.Headers[tea.StringValue(key)]
-				}
-				headers["content-type"] = tea.String("application/x-www-form-urlencoded; charset=UTF-8")
+				request.Headers["content-type"] = tea.String("application/x-www-form-urlencoded; charset=UTF-8")
+				headers = request.Headers
 			} else {
 				headers = request.Headers
 			}

--- a/alibabacloud-gateway-pds/java/src/main/java/com/aliyun/gateway/pds/Client.java
+++ b/alibabacloud-gateway-pds/java/src/main/java/com/aliyun/gateway/pds/Client.java
@@ -90,11 +90,8 @@ public class Client extends com.aliyun.gateway.spi.Client {
                 if (!com.aliyun.teautil.Common.isUnset(request.headers.get("content-type"))) {
                     headers = request.headers;
                 } else if (com.aliyun.darabonbastring.Client.equals(request.reqBodyType, "formData") && com.aliyun.darabonbastring.Client.equals(request.action, "DownloadFile") && com.aliyun.darabonbastring.Client.equals(request.pathname, "/v2/file/download")) {
-                    java.util.List<String> headersArray = com.aliyun.darabonba.map.Client.keySet(request.headers);
-                    for (String key : headersArray) {
-                        headers.put(key, request.headers.get(key));
-                    }
-                    headers.put("content-type", "application/x-www-form-urlencoded; charset=UTF-8");
+                    request.headers.put("content-type", "application/x-www-form-urlencoded; charset=UTF-8");
+                    headers = request.headers;
                 } else {
                     headers = request.headers;
                 }

--- a/alibabacloud-gateway-pds/main.tea
+++ b/alibabacloud-gateway-pds/main.tea
@@ -91,11 +91,8 @@ async function modifyRequest(context: SPI.InterceptorContext, attributeMap: SPI.
       if (!Util.isUnset(request.headers.content-type)) {
         headers = request.headers;
       } else if (String.equals(request.reqBodyType, 'formData') && String.equals(request.action, 'DownloadFile') && String.equals(request.pathname, '/v2/file/download')) {
-        var headersArray : [string] = Map.keySet(request.headers);
-        for(var key : headersArray) {
-          headers[key] = request.headers[key];
-        } 
-        headers.content-type = 'application/x-www-form-urlencoded; charset=UTF-8';
+        request.headers.content-type = 'application/x-www-form-urlencoded; charset=UTF-8';
+        headers = request.headers;
       } else {
           headers = request.headers;
       }

--- a/alibabacloud-gateway-pds/php/src/Client.php
+++ b/alibabacloud-gateway-pds/php/src/Client.php
@@ -107,11 +107,8 @@ class Client extends DarabonbaGatewaySpiClient
                 if (!Utils::isUnset(@$request->headers["content-type"])) {
                     $headers = $request->headers;
                 } else if (StringUtil::equals($request->reqBodyType, "formData") && StringUtil::equals($request->action, "DownloadFile") && StringUtil::equals($request->pathname, "/v2/file/download")) {
-                    $headersArray = MapUtil::keySet($request->headers);
-                    foreach ($headersArray as $key) {
-                        $headers[$key] = @$request->headers[$key];
-                    }
-                    @$headers["content-type"] = "application/x-www-form-urlencoded; charset=UTF-8";
+                    @$request->headers["content-type"] = "application/x-www-form-urlencoded; charset=UTF-8";
+                    $headers = $request->headers;
                 } else {
                     $headers = $request->headers;
                 }

--- a/alibabacloud-gateway-pds/python/alibabacloud_gateway_pds/client.py
+++ b/alibabacloud-gateway-pds/python/alibabacloud_gateway_pds/client.py
@@ -99,10 +99,8 @@ class Client(SPIClient):
                 if not UtilClient.is_unset(request.headers.get('content-type')):
                     headers = request.headers
                 elif StringClient.equals(request.req_body_type, 'formData') and StringClient.equals(request.action, 'DownloadFile') and StringClient.equals(request.pathname, '/v2/file/download'):
-                    headers_array = MapClient.key_set(request.headers)
-                    for key in headers_array:
-                        headers[key] = request.headers.get(key)
-                    headers['content-type'] = 'application/x-www-form-urlencoded; charset=UTF-8'
+                    request.headers['content-type'] = 'application/x-www-form-urlencoded; charset=UTF-8'
+                    headers = request.headers
                 else:
                     headers = request.headers
                 if StringClient.equals(signature_version, 'v4'):
@@ -177,10 +175,8 @@ class Client(SPIClient):
                 if not UtilClient.is_unset(request.headers.get('content-type')):
                     headers = request.headers
                 elif StringClient.equals(request.req_body_type, 'formData') and StringClient.equals(request.action, 'DownloadFile') and StringClient.equals(request.pathname, '/v2/file/download'):
-                    headers_array = MapClient.key_set(request.headers)
-                    for key in headers_array:
-                        headers[key] = request.headers.get(key)
-                    headers['content-type'] = 'application/x-www-form-urlencoded; charset=UTF-8'
+                    request.headers['content-type'] = 'application/x-www-form-urlencoded; charset=UTF-8'
+                    headers = request.headers
                 else:
                     headers = request.headers
                 if StringClient.equals(signature_version, 'v4'):

--- a/alibabacloud-gateway-pds/ts/src/client.ts
+++ b/alibabacloud-gateway-pds/ts/src/client.ts
@@ -96,12 +96,8 @@ export default class Client extends SPI {
         if (!Util.isUnset(request.headers["content-type"])) {
           headers = request.headers;
         } else if (String.equals(request.reqBodyType, "formData") && String.equals(request.action, "DownloadFile") && String.equals(request.pathname, "/v2/file/download")) {
-          let headersArray: string[] = Map.keySet(request.headers);
-
-          for (let key of headersArray) {
-            headers[key] = request.headers[key];
-          }
-          headers["content-type"] = "application/x-www-form-urlencoded; charset=UTF-8";
+          request.headers["content-type"] = "application/x-www-form-urlencoded; charset=UTF-8";
+          headers = request.headers;
         } else {
           headers = request.headers;
         }


### PR DESCRIPTION
## Summary
- Set `content-type` on `request.headers` for DownloadFile before signing instead of only on a local headers copy.
- Sync fix across main.tea and Java/Go/TS/Python/PHP/C# generated clients.