### PR TITLE
fix(gateway): use exact equality for signed-header dedup

### DIFF
--- a/alibabacloud-gateway-fc/csharp/core/Client.cs
+++ b/alibabacloud-gateway-fc/csharp/core/Client.cs
@@ -757,42 +757,42 @@ namespace AlibabaCloud.GatewayFc
         {
             List<string> headersArray = AlibabaCloud.DarabonbaMap.MapUtil.KeySet(headers);
             List<string> sortedHeadersArray = AlibabaCloud.DarabonbaArray.ArrayUtil.AscSort(headersArray);
-            string tmp = "";
-            string separator = "";
+            List<string> result = new List<string>
+            {
+            };
 
             foreach (var key in sortedHeadersArray) {
                 string lowerKey = AlibabaCloud.DarabonbaString.StringUtil.ToLower(key);
                 if (AlibabaCloud.DarabonbaString.StringUtil.HasPrefix(lowerKey, "x-acs-") || AlibabaCloud.DarabonbaString.StringUtil.Equals(lowerKey, "host") || AlibabaCloud.DarabonbaString.StringUtil.Equals(lowerKey, "content-type"))
                 {
-                    if (!AlibabaCloud.DarabonbaString.StringUtil.Contains(tmp, lowerKey))
+                    if (!AlibabaCloud.DarabonbaArray.ArrayUtil.Contains(result, lowerKey))
                     {
-                        tmp = "" + tmp + separator + lowerKey;
-                        separator = ";";
+                        AlibabaCloud.DarabonbaArray.ArrayUtil.Append(result, lowerKey);
                     }
                 }
             }
-            return AlibabaCloud.DarabonbaString.StringUtil.Split(tmp, ";", null);
+            return result;
         }
 
         public async Task<List<string>> GetSignedHeadersAsync(Dictionary<string, string> headers)
         {
             List<string> headersArray = AlibabaCloud.DarabonbaMap.MapUtil.KeySet(headers);
             List<string> sortedHeadersArray = AlibabaCloud.DarabonbaArray.ArrayUtil.AscSort(headersArray);
-            string tmp = "";
-            string separator = "";
+            List<string> result = new List<string>
+            {
+            };
 
             foreach (var key in sortedHeadersArray) {
                 string lowerKey = AlibabaCloud.DarabonbaString.StringUtil.ToLower(key);
                 if (AlibabaCloud.DarabonbaString.StringUtil.HasPrefix(lowerKey, "x-acs-") || AlibabaCloud.DarabonbaString.StringUtil.Equals(lowerKey, "host") || AlibabaCloud.DarabonbaString.StringUtil.Equals(lowerKey, "content-type"))
                 {
-                    if (!AlibabaCloud.DarabonbaString.StringUtil.Contains(tmp, lowerKey))
+                    if (!AlibabaCloud.DarabonbaArray.ArrayUtil.Contains(result, lowerKey))
                     {
-                        tmp = "" + tmp + separator + lowerKey;
-                        separator = ";";
+                        AlibabaCloud.DarabonbaArray.ArrayUtil.Append(result, lowerKey);
                     }
                 }
             }
-            return AlibabaCloud.DarabonbaString.StringUtil.Split(tmp, ";", null);
+            return result;
         }
 
         public Dictionary<string, object> SignRequest(HttpRequest request, Aliyun.Credentials.Client credential)

--- a/alibabacloud-gateway-fc/golang/client/client.go
+++ b/alibabacloud-gateway-fc/golang/client/client.go
@@ -558,22 +558,18 @@ func (client *Client) BuildCanonicalizedHeadersForPop(headers map[string]*string
 func (client *Client) GetSignedHeaders(headers map[string]*string) (_result []*string, _err error) {
 	headersArray := map_.KeySet(headers)
 	sortedHeadersArray := array.AscSort(headersArray)
-	tmp := tea.String("")
-	separator := tea.String("")
+	result := []*string{}
 	for _, key := range sortedHeadersArray {
 		lowerKey := string_.ToLower(key)
 		if tea.BoolValue(string_.HasPrefix(lowerKey, tea.String("x-acs-"))) || tea.BoolValue(string_.Equals(lowerKey, tea.String("host"))) || tea.BoolValue(string_.Equals(lowerKey, tea.String("content-type"))) {
-			if !tea.BoolValue(string_.Contains(tmp, lowerKey)) {
-				tmp = tea.String(tea.StringValue(tmp) + tea.StringValue(separator) + tea.StringValue(lowerKey))
-				separator = tea.String(";")
+			if !tea.BoolValue(array.Contains(result, lowerKey)) {
+				result = append(result, lowerKey)
 			}
 
 		}
 
 	}
-	_result = make([]*string, 0)
-	_body := string_.Split(tmp, tea.String(";"), nil)
-	_result = _body
+	_result = result
 	return _result, _err
 }
 

--- a/alibabacloud-gateway-fc/java/src/main/java/com/aliyun/gateway/fc/Client.java
+++ b/alibabacloud-gateway-fc/java/src/main/java/com/aliyun/gateway/fc/Client.java
@@ -336,20 +336,18 @@ public class Client extends com.aliyun.gateway.spi.Client {
     public java.util.List<String> getSignedHeaders(java.util.Map<String, String> headers) throws Exception {
         java.util.List<String> headersArray = com.aliyun.darabonba.map.Client.keySet(headers);
         java.util.List<String> sortedHeadersArray = com.aliyun.darabonba.array.Client.ascSort(headersArray);
-        String tmp = "";
-        String separator = "";
+        java.util.List<String> result = new java.util.ArrayList<>();
         for (String key : sortedHeadersArray) {
             String lowerKey = com.aliyun.darabonbastring.Client.toLower(key);
             if (com.aliyun.darabonbastring.Client.hasPrefix(lowerKey, "x-acs-") || com.aliyun.darabonbastring.Client.equals(lowerKey, "host") || com.aliyun.darabonbastring.Client.equals(lowerKey, "content-type")) {
-                if (!com.aliyun.darabonbastring.Client.contains(tmp, lowerKey)) {
-                    tmp = "" + tmp + "" + separator + "" + lowerKey + "";
-                    separator = ";";
+                if (!com.aliyun.darabonba.array.Client.contains(result, lowerKey)) {
+                    com.aliyun.darabonba.array.Client.append(result, lowerKey);
                 }
 
             }
 
         }
-        return com.aliyun.darabonbastring.Client.split(tmp, ";", null);
+        return result;
     }
 
     public java.util.Map<String, ?> signRequest(HttpRequest request, com.aliyun.credentials.Client credential) throws Exception {

--- a/alibabacloud-gateway-fc/main.tea
+++ b/alibabacloud-gateway-fc/main.tea
@@ -317,19 +317,18 @@ async function buildCanonicalizedHeadersForPop(headers: map[string]string): stri
 async function getSignedHeaders(headers: map[string]string): [string] {
   var headersArray : [string] = Map.keySet(headers);
   var sortedHeadersArray = Array.ascSort(headersArray);
-  var tmp : string = '';
-  var separator : string = '';
+  var result : [string] = [];
   for(var key : sortedHeadersArray) {
     var lowerKey = String.toLower(key);
     if (String.hasPrefix(lowerKey, 'x-acs-') || String.equals(lowerKey, 'host')
             || String.equals(lowerKey, 'content-type')) {
-      if (!String.contains(tmp, lowerKey)) {
-        tmp = `${tmp}${separator}${lowerKey}`;
-        separator = ';';
+      // Array.contains: exact equality; String.contains on joined keys mis-dedups prefixes.
+      if (!Array.contains(result, lowerKey)) {
+        Array.append(result, lowerKey);
       }
     }
   }
-  return String.split(tmp, ';', null);
+  return result;
 }
 
 model HttpRequest = {

--- a/alibabacloud-gateway-fc/php/src/Client.php
+++ b/alibabacloud-gateway-fc/php/src/Client.php
@@ -432,18 +432,16 @@ class Client extends DarabonbaGatewaySpiClient
     {
         $headersArray = MapUtil::keySet($headers);
         $sortedHeadersArray = ArrayUtil::ascSort($headersArray);
-        $tmp = "";
-        $separator = "";
+        $result = [];
         foreach ($sortedHeadersArray as $key) {
             $lowerKey = StringUtil::toLower($key);
             if (StringUtil::hasPrefix($lowerKey, "x-acs-") || StringUtil::equals($lowerKey, "host") || StringUtil::equals($lowerKey, "content-type")) {
-                if (!StringUtil::contains($tmp, $lowerKey)) {
-                    $tmp = "" . $tmp . "" . $separator . "" . $lowerKey . "";
-                    $separator = ";";
+                if (!ArrayUtil::contains($result, $lowerKey)) {
+                    ArrayUtil::append($result, $lowerKey);
                 }
             }
         }
-        return StringUtil::split($tmp, ";", null);
+        return $result;
     }
 
     /**

--- a/alibabacloud-gateway-fc/python/alibabacloud_gateway_fc/client.py
+++ b/alibabacloud-gateway-fc/python/alibabacloud_gateway_fc/client.py
@@ -641,15 +641,13 @@ class Client(SPIClient):
     ) -> List[str]:
         headers_array = MapClient.key_set(headers)
         sorted_headers_array = ArrayClient.asc_sort(headers_array)
-        tmp = ''
-        separator = ''
+        result = []
         for key in sorted_headers_array:
             lower_key = StringClient.to_lower(key)
             if StringClient.has_prefix(lower_key, 'x-acs-') or StringClient.equals(lower_key, 'host') or StringClient.equals(lower_key, 'content-type'):
-                if not StringClient.contains(tmp, lower_key):
-                    tmp = f'{tmp}{separator}{lower_key}'
-                    separator = ';'
-        return StringClient.split(tmp, ';', None)
+                if not ArrayClient.contains(result, lower_key):
+                    result.append(lower_key)
+        return result
 
     async def get_signed_headers_async(
         self,
@@ -657,15 +655,13 @@ class Client(SPIClient):
     ) -> List[str]:
         headers_array = MapClient.key_set(headers)
         sorted_headers_array = ArrayClient.asc_sort(headers_array)
-        tmp = ''
-        separator = ''
+        result = []
         for key in sorted_headers_array:
             lower_key = StringClient.to_lower(key)
             if StringClient.has_prefix(lower_key, 'x-acs-') or StringClient.equals(lower_key, 'host') or StringClient.equals(lower_key, 'content-type'):
-                if not StringClient.contains(tmp, lower_key):
-                    tmp = f'{tmp}{separator}{lower_key}'
-                    separator = ';'
-        return StringClient.split(tmp, ';', None)
+                if not ArrayClient.contains(result, lower_key):
+                    result.append(lower_key)
+        return result
 
     def sign_request(
         self,

--- a/alibabacloud-gateway-fc/python2/alibabacloud_gateway_fc/client.py
+++ b/alibabacloud-gateway-fc/python2/alibabacloud_gateway_fc/client.py
@@ -266,15 +266,13 @@ class Client(SPIClient):
     def get_signed_headers(self, headers):
         headers_array = MapClient.key_set(headers)
         sorted_headers_array = ArrayClient.asc_sort(headers_array)
-        tmp = ''
-        separator = ''
+        result = []
         for key in sorted_headers_array:
             lower_key = StringClient.to_lower(key)
             if StringClient.has_prefix(lower_key, 'x-acs-') or StringClient.equals(lower_key, 'host') or StringClient.equals(lower_key, 'content-type'):
-                if not StringClient.contains(tmp, lower_key):
-                    tmp = '%s%s%s' % (TeaConverter.to_unicode(tmp), TeaConverter.to_unicode(separator), TeaConverter.to_unicode(lower_key))
-                    separator = ';'
-        return StringClient.split(tmp, ';', None)
+                if not ArrayClient.contains(result, lower_key):
+                    result.append(lower_key)
+        return result
 
     def sign_request(self, request, credential):
         http_request = gateway_fc_models.HttpRequest(

--- a/alibabacloud-gateway-fc/ts/src/client.ts
+++ b/alibabacloud-gateway-fc/ts/src/client.ts
@@ -375,21 +375,19 @@ export default class Client extends SPI {
   async getSignedHeaders(headers: {[key: string ]: string}): Promise<string[]> {
     let headersArray : string[] = Map.keySet(headers);
     let sortedHeadersArray = Array.ascSort(headersArray);
-    let tmp : string = "";
-    let separator : string = "";
+    let result : string[] = [];
 
     for (let key of sortedHeadersArray) {
       let lowerKey = String.toLower(key);
       if (String.hasPrefix(lowerKey, "x-acs-") || String.equals(lowerKey, "host") || String.equals(lowerKey, "content-type")) {
-        if (!String.contains(tmp, lowerKey)) {
-          tmp = `${tmp}${separator}${lowerKey}`;
-          separator = ";";
+        if (!Array.contains(result, lowerKey)) {
+          Array.append(result, lowerKey);
         }
 
       }
 
     }
-    return String.split(tmp, ";", null);
+    return result;
   }
 
   async signRequest(request: HttpRequest, credential: Credential): Promise<{[key: string ]: any}> {

--- a/alibabacloud-gateway-pds/csharp/core/Client.cs
+++ b/alibabacloud-gateway-pds/csharp/core/Client.cs
@@ -561,42 +561,42 @@ namespace AlibabaCloud.GatewayPds
         {
             List<string> headersArray = AlibabaCloud.DarabonbaMap.MapUtil.KeySet(headers);
             List<string> sortedHeadersArray = AlibabaCloud.DarabonbaArray.ArrayUtil.AscSort(headersArray);
-            string tmp = "";
-            string separator = "";
+            List<string> result = new List<string>
+            {
+            };
 
             foreach (var key in sortedHeadersArray) {
                 string lowerKey = AlibabaCloud.DarabonbaString.StringUtil.ToLower(key);
                 if (AlibabaCloud.DarabonbaString.StringUtil.HasPrefix(lowerKey, "x-acs-"))
                 {
-                    if (!AlibabaCloud.DarabonbaString.StringUtil.Contains(tmp, lowerKey))
+                    if (!AlibabaCloud.DarabonbaArray.ArrayUtil.Contains(result, lowerKey))
                     {
-                        tmp = "" + tmp + separator + lowerKey;
-                        separator = ";";
+                        AlibabaCloud.DarabonbaArray.ArrayUtil.Append(result, lowerKey);
                     }
                 }
             }
-            return AlibabaCloud.DarabonbaString.StringUtil.Split(tmp, ";", null);
+            return result;
         }
 
         public async Task<List<string>> GetSignedHeadersAsync(Dictionary<string, string> headers)
         {
             List<string> headersArray = AlibabaCloud.DarabonbaMap.MapUtil.KeySet(headers);
             List<string> sortedHeadersArray = AlibabaCloud.DarabonbaArray.ArrayUtil.AscSort(headersArray);
-            string tmp = "";
-            string separator = "";
+            List<string> result = new List<string>
+            {
+            };
 
             foreach (var key in sortedHeadersArray) {
                 string lowerKey = AlibabaCloud.DarabonbaString.StringUtil.ToLower(key);
                 if (AlibabaCloud.DarabonbaString.StringUtil.HasPrefix(lowerKey, "x-acs-"))
                 {
-                    if (!AlibabaCloud.DarabonbaString.StringUtil.Contains(tmp, lowerKey))
+                    if (!AlibabaCloud.DarabonbaArray.ArrayUtil.Contains(result, lowerKey))
                     {
-                        tmp = "" + tmp + separator + lowerKey;
-                        separator = ";";
+                        AlibabaCloud.DarabonbaArray.ArrayUtil.Append(result, lowerKey);
                     }
                 }
             }
-            return AlibabaCloud.DarabonbaString.StringUtil.Split(tmp, ";", null);
+            return result;
         }
 
         public string GetRegion(string endpoint)

--- a/alibabacloud-gateway-pds/golang/client/client.go
+++ b/alibabacloud-gateway-pds/golang/client/client.go
@@ -348,22 +348,18 @@ func (client *Client) BuildCanonicalizedHeaders(headers map[string]*string) (_re
 func (client *Client) GetSignedHeaders(headers map[string]*string) (_result []*string, _err error) {
 	headersArray := map_.KeySet(headers)
 	sortedHeadersArray := array.AscSort(headersArray)
-	tmp := tea.String("")
-	separator := tea.String("")
+	result := []*string{}
 	for _, key := range sortedHeadersArray {
 		lowerKey := string_.ToLower(key)
 		if tea.BoolValue(string_.HasPrefix(lowerKey, tea.String("x-acs-"))) {
-			if !tea.BoolValue(string_.Contains(tmp, lowerKey)) {
-				tmp = tea.String(tea.StringValue(tmp) + tea.StringValue(separator) + tea.StringValue(lowerKey))
-				separator = tea.String(";")
+			if !tea.BoolValue(array.Contains(result, lowerKey)) {
+				result = append(result, lowerKey)
 			}
 
 		}
 
 	}
-	_result = make([]*string, 0)
-	_body := string_.Split(tmp, tea.String(";"), nil)
-	_result = _body
+	_result = result
 	return _result, _err
 }
 

--- a/alibabacloud-gateway-pds/java/src/main/java/com/aliyun/gateway/pds/Client.java
+++ b/alibabacloud-gateway-pds/java/src/main/java/com/aliyun/gateway/pds/Client.java
@@ -243,20 +243,18 @@ public class Client extends com.aliyun.gateway.spi.Client {
     public java.util.List<String> getSignedHeaders(java.util.Map<String, String> headers) throws Exception {
         java.util.List<String> headersArray = com.aliyun.darabonba.map.Client.keySet(headers);
         java.util.List<String> sortedHeadersArray = com.aliyun.darabonba.array.Client.ascSort(headersArray);
-        String tmp = "";
-        String separator = "";
+        java.util.List<String> result = new java.util.ArrayList<>();
         for (String key : sortedHeadersArray) {
             String lowerKey = com.aliyun.darabonbastring.Client.toLower(key);
             if (com.aliyun.darabonbastring.Client.hasPrefix(lowerKey, "x-acs-")) {
-                if (!com.aliyun.darabonbastring.Client.contains(tmp, lowerKey)) {
-                    tmp = "" + tmp + "" + separator + "" + lowerKey + "";
-                    separator = ";";
+                if (!com.aliyun.darabonba.array.Client.contains(result, lowerKey)) {
+                    com.aliyun.darabonba.array.Client.append(result, lowerKey);
                 }
 
             }
 
         }
-        return com.aliyun.darabonbastring.Client.split(tmp, ";", null);
+        return result;
     }
 
     public String getRegion(String endpoint) throws Exception {

--- a/alibabacloud-gateway-pds/main.tea
+++ b/alibabacloud-gateway-pds/main.tea
@@ -229,18 +229,17 @@ async function buildCanonicalizedHeaders(headers: map[string]string): string {
 async function getSignedHeaders(headers: map[string]string): [string] {
   var headersArray : [string] = Map.keySet(headers);
   var sortedHeadersArray = Array.ascSort(headersArray);
-  var tmp : string = '';
-  var separator : string = '';
+  var result : [string] = [];
   for(var key : sortedHeadersArray) {
     var lowerKey = String.toLower(key);
     if (String.hasPrefix(lowerKey, 'x-acs-')) {
-      if (!String.contains(tmp, lowerKey)) {
-        tmp = `${tmp}${separator}${lowerKey}`;
-        separator = ';';
+      // Array.contains: exact equality; String.contains on joined keys mis-dedups prefixes.
+      if (!Array.contains(result, lowerKey)) {
+        Array.append(result, lowerKey);
       }
     }
   }
-  return String.split(tmp, ';', null);
+  return result;
 }
 
 function getRegion(endpoint: string): string {

--- a/alibabacloud-gateway-pds/php/src/Client.php
+++ b/alibabacloud-gateway-pds/php/src/Client.php
@@ -298,18 +298,16 @@ class Client extends DarabonbaGatewaySpiClient
     {
         $headersArray = MapUtil::keySet($headers);
         $sortedHeadersArray = ArrayUtil::ascSort($headersArray);
-        $tmp = "";
-        $separator = "";
+        $result = [];
         foreach ($sortedHeadersArray as $key) {
             $lowerKey = StringUtil::toLower($key);
             if (StringUtil::hasPrefix($lowerKey, "x-acs-")) {
-                if (!StringUtil::contains($tmp, $lowerKey)) {
-                    $tmp = "" . $tmp . "" . $separator . "" . $lowerKey . "";
-                    $separator = ";";
+                if (!ArrayUtil::contains($result, $lowerKey)) {
+                    ArrayUtil::append($result, $lowerKey);
                 }
             }
         }
-        return StringUtil::split($tmp, ";", null);
+        return $result;
     }
 
     /**

--- a/alibabacloud-gateway-pds/python/alibabacloud_gateway_pds/client.py
+++ b/alibabacloud-gateway-pds/python/alibabacloud_gateway_pds/client.py
@@ -442,15 +442,13 @@ class Client(SPIClient):
     ) -> List[str]:
         headers_array = MapClient.key_set(headers)
         sorted_headers_array = ArrayClient.asc_sort(headers_array)
-        tmp = ''
-        separator = ''
+        result = []
         for key in sorted_headers_array:
             lower_key = StringClient.to_lower(key)
             if StringClient.has_prefix(lower_key, 'x-acs-'):
-                if not StringClient.contains(tmp, lower_key):
-                    tmp = f'{tmp}{separator}{lower_key}'
-                    separator = ';'
-        return StringClient.split(tmp, ';', None)
+                if not ArrayClient.contains(result, lower_key):
+                    result.append(lower_key)
+        return result
 
     async def get_signed_headers_async(
         self,
@@ -458,15 +456,13 @@ class Client(SPIClient):
     ) -> List[str]:
         headers_array = MapClient.key_set(headers)
         sorted_headers_array = ArrayClient.asc_sort(headers_array)
-        tmp = ''
-        separator = ''
+        result = []
         for key in sorted_headers_array:
             lower_key = StringClient.to_lower(key)
             if StringClient.has_prefix(lower_key, 'x-acs-'):
-                if not StringClient.contains(tmp, lower_key):
-                    tmp = f'{tmp}{separator}{lower_key}'
-                    separator = ';'
-        return StringClient.split(tmp, ';', None)
+                if not ArrayClient.contains(result, lower_key):
+                    result.append(lower_key)
+        return result
 
     def get_region(
         self,

--- a/alibabacloud-gateway-pds/python2/alibabacloud_gateway_pds/client.py
+++ b/alibabacloud-gateway-pds/python2/alibabacloud_gateway_pds/client.py
@@ -163,12 +163,10 @@ class Client(SPIClient):
     def get_signed_headers(self, headers):
         headers_array = MapClient.key_set(headers)
         sorted_headers_array = ArrayClient.asc_sort(headers_array)
-        tmp = ''
-        separator = ''
+        result = []
         for key in sorted_headers_array:
             lower_key = StringClient.to_lower(key)
             if StringClient.has_prefix(lower_key, 'x-acs-'):
-                if not StringClient.contains(tmp, lower_key):
-                    tmp = '%s%s%s' % (TeaConverter.to_unicode(tmp), TeaConverter.to_unicode(separator), TeaConverter.to_unicode(lower_key))
-                    separator = ';'
-        return StringClient.split(tmp, ';', None)
+                if not ArrayClient.contains(result, lower_key):
+                    result.append(lower_key)
+        return result

--- a/alibabacloud-gateway-pds/ts/src/client.ts
+++ b/alibabacloud-gateway-pds/ts/src/client.ts
@@ -252,21 +252,19 @@ export default class Client extends SPI {
   async getSignedHeaders(headers: { [key: string]: string }): Promise<string[]> {
     let headersArray: string[] = Map.keySet(headers);
     let sortedHeadersArray = Array.ascSort(headersArray);
-    let tmp: string = "";
-    let separator: string = "";
+    let result: string[] = [];
 
     for (let key of sortedHeadersArray) {
       let lowerKey = String.toLower(key);
       if (String.hasPrefix(lowerKey, "x-acs-")) {
-        if (!String.contains(tmp, lowerKey)) {
-          tmp = `${tmp}${separator}${lowerKey}`;
-          separator = ";";
+        if (!Array.contains(result, lowerKey)) {
+          Array.append(result, lowerKey);
         }
 
       }
 
     }
-    return String.split(tmp, ";", null);
+    return result;
   }
 
   getRegion(endpoint: string): string {

--- a/alibabacloud-gateway-pop/csharp/core/Client.cs
+++ b/alibabacloud-gateway-pop/csharp/core/Client.cs
@@ -575,16 +575,13 @@ namespace AlibabaCloud.GatewayPop
             // lower header key
             List<string> headersArray = AlibabaCloud.DarabonbaMap.MapUtil.KeySet(headers);
             Dictionary<string, string> newHeaders = new Dictionary<string, string>(){};
-            string tmp = "";
-
             foreach (var key in headersArray) {
                 string lowerKey = AlibabaCloud.DarabonbaString.StringUtil.ToLower(key);
                 string value = headers.Get(key);
                 if (!AlibabaCloud.TeaUtil.Common.IsUnset(value))
                 {
-                    if (!AlibabaCloud.DarabonbaString.StringUtil.Contains(tmp, lowerKey) || AlibabaCloud.DarabonbaString.StringUtil.Equals(lowerKey, "host"))
+                    if (AlibabaCloud.TeaUtil.Common.IsUnset(newHeaders.Get(lowerKey)) || AlibabaCloud.DarabonbaString.StringUtil.Equals(lowerKey, "host"))
                     {
-                        tmp = "" + tmp + "," + lowerKey;
                         newHeaders[lowerKey] = AlibabaCloud.DarabonbaString.StringUtil.Trim(value);
                     }
                     else
@@ -618,20 +615,20 @@ namespace AlibabaCloud.GatewayPop
                 }
             }
             List<string> sortedHeadersArray = AlibabaCloud.DarabonbaArray.ArrayUtil.AscSort(newHeadersArray);
-            string tmp = "";
-            string separator = "";
+            List<string> result = new List<string>
+            {
+            };
 
             foreach (var key in sortedHeadersArray) {
                 if (AlibabaCloud.DarabonbaString.StringUtil.HasPrefix(key, "x-acs-") || AlibabaCloud.DarabonbaString.StringUtil.Equals(key, "host") || AlibabaCloud.DarabonbaString.StringUtil.Equals(key, "content-type"))
                 {
-                    if (!AlibabaCloud.DarabonbaString.StringUtil.Contains(tmp, key))
+                    if (!AlibabaCloud.DarabonbaArray.ArrayUtil.Contains(result, key))
                     {
-                        tmp = "" + tmp + separator + key;
-                        separator = ";";
+                        AlibabaCloud.DarabonbaArray.ArrayUtil.Append(result, key);
                     }
                 }
             }
-            return AlibabaCloud.DarabonbaString.StringUtil.Split(tmp, ";", null);
+            return result;
         }
 
     }

--- a/alibabacloud-gateway-pop/csharp/tests/UnitTest.cs
+++ b/alibabacloud-gateway-pop/csharp/tests/UnitTest.cs
@@ -104,11 +104,17 @@ namespace tests
                 { "x-acs-foobar", "1" },
                 { "x-acs-foo", "2" }
             };
+            Assert.False(AlibabaCloud.DarabonbaArray.ArrayUtil.Contains(
+                new List<string> { "x-acs-foobar" }, "x-acs-foo"));
             result = client.GetSignedHeaders(prefixHeaders);
             Assert.Equal(3, result.Count);
             Assert.Equal("host", result[0]);
             Assert.Equal("x-acs-foo", result[1]);
             Assert.Equal("x-acs-foobar", result[2]);
+
+            var canonical = client.BuildCanonicalizedHeaders(prefixHeaders);
+            Assert.Contains("x-acs-foo:2\n", canonical);
+            Assert.Contains("x-acs-foobar:1\n", canonical);
         }
     }
 }

--- a/alibabacloud-gateway-pop/csharp/tests/UnitTest.cs
+++ b/alibabacloud-gateway-pop/csharp/tests/UnitTest.cs
@@ -41,7 +41,7 @@ namespace tests
             // 测试空headers
             var emptyHeaders = new Dictionary<string, string>();
             var result = client.GetSignedHeaders(emptyHeaders);
-            Assert.Equal(1, result.Count);
+            Assert.Equal(0, result.Count);
 
             // 测试只包含需要签名的headers
             var headers = new Dictionary<string, string>
@@ -96,6 +96,19 @@ namespace tests
             Assert.Equal("content-type", result[0]);
             Assert.Equal("host", result[1]);
             Assert.Equal("x-acs-action", result[2]);
+
+            // Prefix pairs must not be mis-deduped via substring contains
+            var prefixHeaders = new Dictionary<string, string>
+            {
+                { "host", "example.com" },
+                { "x-acs-foobar", "1" },
+                { "x-acs-foo", "2" }
+            };
+            result = client.GetSignedHeaders(prefixHeaders);
+            Assert.Equal(3, result.Count);
+            Assert.Equal("host", result[0]);
+            Assert.Equal("x-acs-foo", result[1]);
+            Assert.Equal("x-acs-foobar", result[2]);
         }
     }
 }

--- a/alibabacloud-gateway-pop/golang/client/client.go
+++ b/alibabacloud-gateway-pop/golang/client/client.go
@@ -420,13 +420,11 @@ func (client *Client) BuildCanonicalizedHeaders(headers map[string]*string) (_re
 	// lower header key
 	headersArray := map_.KeySet(headers)
 	newHeaders := make(map[string]*string)
-	tmp := tea.String("")
 	for _, key := range headersArray {
 		lowerKey := string_.ToLower(key)
 		value := headers[tea.StringValue(key)]
 		if !tea.BoolValue(util.IsUnset(value)) {
-			if !tea.BoolValue(string_.Contains(tmp, lowerKey)) || tea.BoolValue(string_.Equals(lowerKey, tea.String("host"))) {
-				tmp = tea.String(tea.StringValue(tmp) + "," + tea.StringValue(lowerKey))
+			if tea.BoolValue(util.IsUnset(newHeaders[tea.StringValue(lowerKey)])) || tea.BoolValue(string_.Equals(lowerKey, tea.String("host"))) {
 				newHeaders[tea.StringValue(lowerKey)] = string_.Trim(value)
 			} else {
 				newHeaders[tea.StringValue(lowerKey)] = tea.String(tea.StringValue(newHeaders[tea.StringValue(lowerKey)]) + "," + tea.StringValue(string_.Trim(value)))
@@ -456,20 +454,16 @@ func (client *Client) GetSignedHeaders(headers map[string]*string) (_result []*s
 
 	}
 	sortedHeadersArray := array.AscSort(newHeadersArray)
-	tmp := tea.String("")
-	separator := tea.String("")
+	result := []*string{}
 	for _, key := range sortedHeadersArray {
 		if tea.BoolValue(string_.HasPrefix(key, tea.String("x-acs-"))) || tea.BoolValue(string_.Equals(key, tea.String("host"))) || tea.BoolValue(string_.Equals(key, tea.String("content-type"))) {
-			if !tea.BoolValue(string_.Contains(tmp, key)) {
-				tmp = tea.String(tea.StringValue(tmp) + tea.StringValue(separator) + tea.StringValue(key))
-				separator = tea.String(";")
+			if !tea.BoolValue(array.Contains(result, key)) {
+				result = append(result, key)
 			}
 
 		}
 
 	}
-	_result = make([]*string, 0)
-	_body := string_.Split(tmp, tea.String(";"), nil)
-	_result = _body
+	_result = result
 	return _result
 }

--- a/alibabacloud-gateway-pop/golang/client/client_test.go
+++ b/alibabacloud-gateway-pop/golang/client/client_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"testing"
 
+	array "github.com/alibabacloud-go/darabonba-array/client"
 	"github.com/alibabacloud-go/tea/tea"
 	"github.com/alibabacloud-go/tea/utils"
 )
@@ -83,9 +84,14 @@ func Test_GetSignedHeaders(t *testing.T) {
 		"x-acs-foobar": tea.String("1"),
 		"x-acs-foo":    tea.String("2"),
 	}
+	utils.AssertEqual(t, false, tea.BoolValue(array.Contains([]*string{tea.String("x-acs-foobar")}, tea.String("x-acs-foo"))))
 	result = client.GetSignedHeaders(prefixHeaders)
 	utils.AssertEqual(t, 3, len(result))
 	utils.AssertEqual(t, "host", tea.StringValue(result[0]))
 	utils.AssertEqual(t, "x-acs-foo", tea.StringValue(result[1]))
 	utils.AssertEqual(t, "x-acs-foobar", tea.StringValue(result[2]))
+
+	canonical := tea.StringValue(client.BuildCanonicalizedHeaders(prefixHeaders))
+	utils.AssertContains(t, canonical, "x-acs-foo:2\n")
+	utils.AssertContains(t, canonical, "x-acs-foobar:1\n")
 }

--- a/alibabacloud-gateway-pop/golang/client/client_test.go
+++ b/alibabacloud-gateway-pop/golang/client/client_test.go
@@ -37,7 +37,7 @@ func Test_GetSignedHeaders(t *testing.T) {
 
 	// 测试空headers
 	result := client.GetSignedHeaders(make(map[string]*string))
-	utils.AssertEqual(t, 1, len(result))
+	utils.AssertEqual(t, 0, len(result))
 
 	// 测试只包含需要签名的headers
 	headers := map[string]*string{
@@ -76,4 +76,16 @@ func Test_GetSignedHeaders(t *testing.T) {
 	utils.AssertEqual(t, 2, len(result))
 	utils.AssertEqual(t, "host", tea.StringValue(result[0]))
 	utils.AssertEqual(t, "x-acs-action", tea.StringValue(result[1]))
+
+	// Prefix pairs must not be mis-deduped via substring contains
+	prefixHeaders := map[string]*string{
+		"host":         tea.String("example.com"),
+		"x-acs-foobar": tea.String("1"),
+		"x-acs-foo":    tea.String("2"),
+	}
+	result = client.GetSignedHeaders(prefixHeaders)
+	utils.AssertEqual(t, 3, len(result))
+	utils.AssertEqual(t, "host", tea.StringValue(result[0]))
+	utils.AssertEqual(t, "x-acs-foo", tea.StringValue(result[1]))
+	utils.AssertEqual(t, "x-acs-foobar", tea.StringValue(result[2]))
 }

--- a/alibabacloud-gateway-pop/java/src/main/java/com/aliyun/gateway/pop/Client.java
+++ b/alibabacloud-gateway-pop/java/src/main/java/com/aliyun/gateway/pop/Client.java
@@ -315,13 +315,11 @@ public class Client extends com.aliyun.gateway.spi.Client {
         // lower header key
         java.util.List<String> headersArray = com.aliyun.darabonba.map.Client.keySet(headers);
         java.util.Map<String, String> newHeaders = new java.util.HashMap<>();
-        String tmp = "";
         for (String key : headersArray) {
             String lowerKey = com.aliyun.darabonbastring.Client.toLower(key);
             String value = headers.get(key);
             if (!com.aliyun.teautil.Common.isUnset(value)) {
-                if (!com.aliyun.darabonbastring.Client.contains(tmp, lowerKey) || com.aliyun.darabonbastring.Client.equals(lowerKey, "host")) {
-                    tmp = "" + tmp + "," + lowerKey + "";
+                if (com.aliyun.teautil.Common.isUnset(newHeaders.get(lowerKey)) || com.aliyun.darabonbastring.Client.equals(lowerKey, "host")) {
                     newHeaders.put(lowerKey, com.aliyun.darabonbastring.Client.trim(value));
                 } else {
                     newHeaders.put(lowerKey, "" + newHeaders.get(lowerKey) + "," + com.aliyun.darabonbastring.Client.trim(value) + "");
@@ -350,18 +348,16 @@ public class Client extends com.aliyun.gateway.spi.Client {
 
         }
         java.util.List<String> sortedHeadersArray = com.aliyun.darabonba.array.Client.ascSort(newHeadersArray);
-        String tmp = "";
-        String separator = "";
+        java.util.List<String> result = new java.util.ArrayList<>();
         for (String key : sortedHeadersArray) {
             if (com.aliyun.darabonbastring.Client.hasPrefix(key, "x-acs-") || com.aliyun.darabonbastring.Client.equals(key, "host") || com.aliyun.darabonbastring.Client.equals(key, "content-type")) {
-                if (!com.aliyun.darabonbastring.Client.contains(tmp, key)) {
-                    tmp = "" + tmp + "" + separator + "" + key + "";
-                    separator = ";";
+                if (!com.aliyun.darabonba.array.Client.contains(result, key)) {
+                    com.aliyun.darabonba.array.Client.append(result, key);
                 }
 
             }
 
         }
-        return com.aliyun.darabonbastring.Client.split(tmp, ";", null);
+        return result;
     }
 }

--- a/alibabacloud-gateway-pop/java/src/test/java/com/aliyun/gateway/pop/UnitTest.java
+++ b/alibabacloud-gateway-pop/java/src/test/java/com/aliyun/gateway/pop/UnitTest.java
@@ -39,7 +39,7 @@ public class UnitTest {
         // 测试空headers
         Map<String, String> emptyHeaders = new HashMap<>();
         List<String> result = client.getSignedHeaders(emptyHeaders);
-        Assert.assertEquals(1, result.size());
+        Assert.assertEquals(0, result.size());
 
         // 测试只包含需要签名的headers
         Map<String, String> headers = new HashMap<>();
@@ -86,5 +86,29 @@ public class UnitTest {
         Assert.assertEquals("content-type", result.get(0));
         Assert.assertEquals("host", result.get(1));
         Assert.assertEquals("x-acs-action", result.get(2));
+
+        // Prefix pairs must not be mis-deduped (String.contains would treat x-acs-foo as inside x-acs-foobar)
+        Map<String, String> prefixHeaders = new HashMap<>();
+        prefixHeaders.put("host", "example.com");
+        prefixHeaders.put("x-acs-foobar", "1");
+        prefixHeaders.put("x-acs-foo", "2");
+        result = client.getSignedHeaders(prefixHeaders);
+        Assert.assertEquals(3, result.size());
+        Assert.assertEquals("host", result.get(0));
+        Assert.assertEquals("x-acs-foo", result.get(1));
+        Assert.assertEquals("x-acs-foobar", result.get(2));
+    }
+
+    @Test
+    public void buildCanonicalizedHeadersPrefixTest() throws Exception {
+        Client client = new Client();
+        Map<String, String> headers = new HashMap<>();
+        headers.put("host", "example.com");
+        headers.put("x-acs-foobar", "bar");
+        headers.put("x-acs-foo", "foo");
+        String canonical = client.buildCanonicalizedHeaders(headers);
+        Assert.assertTrue(canonical.contains("x-acs-foo:foo\n"));
+        Assert.assertTrue(canonical.contains("x-acs-foobar:bar\n"));
+        Assert.assertTrue(canonical.contains("host:example.com\n"));
     }
 }

--- a/alibabacloud-gateway-pop/java/src/test/java/com/aliyun/gateway/pop/UnitTest.java
+++ b/alibabacloud-gateway-pop/java/src/test/java/com/aliyun/gateway/pop/UnitTest.java
@@ -92,6 +92,8 @@ public class UnitTest {
         prefixHeaders.put("host", "example.com");
         prefixHeaders.put("x-acs-foobar", "1");
         prefixHeaders.put("x-acs-foo", "2");
+        Assert.assertFalse(com.aliyun.darabonba.array.Client.contains(
+            java.util.Collections.singletonList("x-acs-foobar"), "x-acs-foo"));
         result = client.getSignedHeaders(prefixHeaders);
         Assert.assertEquals(3, result.size());
         Assert.assertEquals("host", result.get(0));

--- a/alibabacloud-gateway-pop/main.tea
+++ b/alibabacloud-gateway-pop/main.tea
@@ -301,13 +301,13 @@ function buildCanonicalizedHeaders(headers: map[string]string): string {
   // lower header key
   var headersArray : [string] = Map.keySet(headers);
   var newHeaders : map[string]string = {};
-  var tmp : string = '';
   for(var key : headersArray) {
     var lowerKey = String.toLower(key);
     var value = headers[key];
     if (!Util.isUnset(value)) {
-      if (!String.contains(tmp, lowerKey) || String.equals(lowerKey, 'host')) {
-        tmp = `${tmp},${lowerKey}`;
+      // Use map membership (exact key) instead of String.contains on a joined
+      // string, which mis-merges prefix pairs like x-acs-foo / x-acs-foobar.
+      if (Util.isUnset(newHeaders[lowerKey]) || String.equals(lowerKey, 'host')) {
         newHeaders[lowerKey] = String.trim(value);
       } else {
         newHeaders[lowerKey] = `${newHeaders[lowerKey]},${String.trim(value)}`;
@@ -334,16 +334,14 @@ function getSignedHeaders(headers: map[string]string): [string] {
     }
   }
   var sortedHeadersArray = Array.ascSort(newHeadersArray);
-  var tmp : string = '';
-  var separator : string = '';
+  var result : [string] = [];
   for(var key : sortedHeadersArray) {
     if (String.hasPrefix(key, 'x-acs-') || String.equals(key, 'host')
             || String.equals(key, 'content-type')) {
-      if (!String.contains(tmp, key)) {
-        tmp = `${tmp}${separator}${key}`;
-        separator = ';';
+      if (!Array.contains(result, key)) {
+        Array.append(result, key);
       }
     }
   }
-  return String.split(tmp, ';', null);
+  return result;
 }

--- a/alibabacloud-gateway-pop/php/src/Client.php
+++ b/alibabacloud-gateway-pop/php/src/Client.php
@@ -393,13 +393,11 @@ class Client extends DarabonbaGatewaySpiClient
         // lower header key
         $headersArray = MapUtil::keySet($headers);
         $newHeaders = [];
-        $tmp = "";
         foreach ($headersArray as $key) {
             $lowerKey = StringUtil::toLower($key);
             $value = @$headers[$key];
             if (!Utils::isUnset($value)) {
-                if (!StringUtil::contains($tmp, $lowerKey) || StringUtil::equals($lowerKey, "host")) {
-                    $tmp = "" . $tmp . "," . $lowerKey . "";
+                if (Utils::isUnset(@$newHeaders[$lowerKey]) || StringUtil::equals($lowerKey, "host")) {
                     $newHeaders[$lowerKey] = StringUtil::trim($value);
                 } else {
                     $newHeaders[$lowerKey] = "" . @$newHeaders[$lowerKey] . "," . StringUtil::trim($value) . "";
@@ -430,16 +428,14 @@ class Client extends DarabonbaGatewaySpiClient
             }
         }
         $sortedHeadersArray = ArrayUtil::ascSort($newHeadersArray);
-        $tmp = "";
-        $separator = "";
+        $result = [];
         foreach ($sortedHeadersArray as $key) {
             if (StringUtil::hasPrefix($key, "x-acs-") || StringUtil::equals($key, "host") || StringUtil::equals($key, "content-type")) {
-                if (!StringUtil::contains($tmp, $key)) {
-                    $tmp = "" . $tmp . "" . $separator . "" . $key . "";
-                    $separator = ";";
+                if (!ArrayUtil::contains($result, $key)) {
+                    ArrayUtil::append($result, $key);
                 }
             }
         }
-        return StringUtil::split($tmp, ";", null);
+        return $result;
     }
 }

--- a/alibabacloud-gateway-pop/php/tests/UnitTest.php
+++ b/alibabacloud-gateway-pop/php/tests/UnitTest.php
@@ -93,6 +93,18 @@ final class UnitTest extends TestCase
         $this->assertEquals("content-type", $result[0]);
         $this->assertEquals("host", $result[1]);
         $this->assertEquals("x-acs-action", $result[2]);
+
+        // Prefix pairs must not be mis-deduped via substring contains
+        $prefixHeaders = [
+            "host" => "example.com",
+            "x-acs-foobar" => "1",
+            "x-acs-foo" => "2"
+        ];
+        $result = $client->getSignedHeaders($prefixHeaders);
+        $this->assertCount(3, $result);
+        $this->assertEquals("host", $result[0]);
+        $this->assertEquals("x-acs-foo", $result[1]);
+        $this->assertEquals("x-acs-foobar", $result[2]);
     }
 
 }

--- a/alibabacloud-gateway-pop/php/tests/UnitTest.php
+++ b/alibabacloud-gateway-pop/php/tests/UnitTest.php
@@ -2,6 +2,7 @@
 
 namespace Darabonba\GatewayPop\Tests;
 
+use AlibabaCloud\Darabonba\ArrayUtil\ArrayUtil;
 use Darabonba\GatewayPop\Client;
 use PHPUnit\Framework\TestCase;
 
@@ -100,6 +101,7 @@ final class UnitTest extends TestCase
             "x-acs-foobar" => "1",
             "x-acs-foo" => "2"
         ];
+        $this->assertFalse(ArrayUtil::contains(["x-acs-foobar"], "x-acs-foo"));
         $result = $client->getSignedHeaders($prefixHeaders);
         $this->assertCount(3, $result);
         $this->assertEquals("host", $result[0]);

--- a/alibabacloud-gateway-pop/python/alibabacloud_gateway_pop/client.py
+++ b/alibabacloud-gateway-pop/python/alibabacloud_gateway_pop/client.py
@@ -461,13 +461,11 @@ class Client(SPIClient):
         # lower header key
         headers_array = MapClient.key_set(headers)
         new_headers = {}
-        tmp = ''
         for key in headers_array:
             lower_key = StringClient.to_lower(key)
             value = headers.get(key)
             if not UtilClient.is_unset(value):
-                if not StringClient.contains(tmp, lower_key) or StringClient.equals(lower_key, 'host'):
-                    tmp = f'{tmp},{lower_key}'
+                if UtilClient.is_unset(new_headers.get(lower_key)) or StringClient.equals(lower_key, 'host'):
                     new_headers[lower_key] = StringClient.trim(value)
                 else:
                     new_headers[lower_key] = f'{new_headers.get(lower_key)},{StringClient.trim(value)}'
@@ -489,11 +487,9 @@ class Client(SPIClient):
             if not UtilClient.is_unset(value):
                 new_headers_array.append(lower_key)
         sorted_headers_array = ArrayClient.asc_sort(new_headers_array)
-        tmp = ''
-        separator = ''
+        result = []
         for key in sorted_headers_array:
             if StringClient.has_prefix(key, 'x-acs-') or StringClient.equals(key, 'host') or StringClient.equals(key, 'content-type'):
-                if not StringClient.contains(tmp, key):
-                    tmp = f'{tmp}{separator}{key}'
-                    separator = ';'
-        return StringClient.split(tmp, ';', None)
+                if not ArrayClient.contains(result, key):
+                    ArrayClient.append(result, key)
+        return result

--- a/alibabacloud-gateway-pop/python/tests/test_client.py
+++ b/alibabacloud-gateway-pop/python/tests/test_client.py
@@ -62,7 +62,15 @@ class TestClient(unittest.TestCase):
         # 测试空headers情况
         headers4 = {}
         result4 = client.get_signed_headers(headers4)
-        self.assertEqual([''], result4)
+        self.assertEqual([], result4)
+
+        # Prefix pairs must not be mis-deduped via substring contains
+        headers_prefix = {
+            'host': 'example.com',
+            'x-acs-foobar': '1',
+            'x-acs-foo': '2'
+        }
+        self.assertEqual(['host', 'x-acs-foo', 'x-acs-foobar'], client.get_signed_headers(headers_prefix))
         
         # 测试包含空值的headers情况
         headers5 = {

--- a/alibabacloud-gateway-pop/python/tests/test_client.py
+++ b/alibabacloud-gateway-pop/python/tests/test_client.py
@@ -1,5 +1,6 @@
 import unittest
 
+from alibabacloud_darabonba_array.client import Client as ArrayClient
 from alibabacloud_gateway_pop.client import Client
 
 
@@ -70,8 +71,12 @@ class TestClient(unittest.TestCase):
             'x-acs-foobar': '1',
             'x-acs-foo': '2'
         }
+        self.assertFalse(ArrayClient.contains(['x-acs-foobar'], 'x-acs-foo'))
         self.assertEqual(['host', 'x-acs-foo', 'x-acs-foobar'], client.get_signed_headers(headers_prefix))
-        
+        canonical = client.build_canonicalized_headers(headers_prefix)
+        self.assertIn('x-acs-foo:2\n', canonical)
+        self.assertIn('x-acs-foobar:1\n', canonical)
+
         # 测试包含空值的headers情况
         headers5 = {
             'host': 'example.com',

--- a/alibabacloud-gateway-pop/python2/alibabacloud_gateway_pop/client.py
+++ b/alibabacloud-gateway-pop/python2/alibabacloud_gateway_pop/client.py
@@ -225,12 +225,10 @@ class Client(SPIClient):
     def get_signed_headers(self, headers):
         headers_array = MapClient.key_set(headers)
         sorted_headers_array = ArrayClient.asc_sort(headers_array)
-        tmp = ''
-        separator = ''
+        result = []
         for key in sorted_headers_array:
             lower_key = StringClient.to_lower(key)
             if StringClient.has_prefix(lower_key, 'x-acs-') or StringClient.equals(lower_key, 'host') or StringClient.equals(lower_key, 'content-type'):
-                if not StringClient.contains(tmp, lower_key):
-                    tmp = '%s%s%s' % (TeaConverter.to_unicode(tmp), TeaConverter.to_unicode(separator), TeaConverter.to_unicode(lower_key))
-                    separator = ';'
-        return StringClient.split(tmp, ';', None)
+                if not ArrayClient.contains(result, lower_key):
+                    ArrayClient.append(result, lower_key)
+        return result

--- a/alibabacloud-gateway-pop/roa.tea
+++ b/alibabacloud-gateway-pop/roa.tea
@@ -187,16 +187,15 @@ async function buildCanonicalizedHeaders(headers: map[string]string): string {
 async function getSignedHeaders(headers: map[string]string): [string] {
   var headersArray : [string] = Map.keySet(headers);
   var sortedHeadersArray = Array.ascSort(headersArray);
-  var tmp : string = '';
-  var separator : string = '';
+  var result : [string] = [];
   for(var key : sortedHeadersArray) {
     var lowerKey = String.toLower(key);
     if (String.hasPrefix(lowerKey, 'x-acs-')) {
-      if (!String.contains(tmp, lowerKey)) {
-        tmp = `${tmp}${separator}${lowerKey}`;
-        separator = ';';
+      // Array.contains: exact equality; String.contains on joined keys mis-dedups prefixes.
+      if (!Array.contains(result, lowerKey)) {
+        Array.append(result, lowerKey);
       }
     }
   }
-  return String.split(tmp, ';', 0);
+  return result;
 }

--- a/alibabacloud-gateway-pop/swift/Package.swift
+++ b/alibabacloud-gateway-pop/swift/Package.swift
@@ -43,6 +43,9 @@ let package = Package(
                         .product(name: "darabonba_Map", package: "darabonba_Map"),
                         .product(name: "darabonba_Array", package: "darabonba_Array")
                     ]),
+            .testTarget(
+                    name: "AlibabacloudGatewayPOPTests",
+                    dependencies: ["AlibabacloudGatewayPOP"]),
         ],
         swiftLanguageVersions: [.v5]
 )

--- a/alibabacloud-gateway-pop/swift/Sources/AlibabacloudGatewayPOP/Client.swift
+++ b/alibabacloud-gateway-pop/swift/Sources/AlibabacloudGatewayPOP/Client.swift
@@ -313,17 +313,15 @@ open class Client : AlibabacloudGatewaySPI.Client {
     public func getSignedHeaders(_ headers: [String: String]) -> [String] {
         var headersArray: [String] = DarabonbaMap.Client.keySet(headers)
         var sortedHeadersArray: [String] = DarabonbaArray.Client.ascSort(headersArray)
-        var tmp: String = ""
-        var separator: String = ""
+        var result: [String] = []
         for key in sortedHeadersArray {
             var lowerKey: String = DarabonbaString.Client.toLower(key)
             if (DarabonbaString.Client.hasPrefix(lowerKey, "x-acs-") || DarabonbaString.Client.equals(lowerKey, "host") || DarabonbaString.Client.equals(lowerKey, "content-type")) {
-                if (!DarabonbaString.Client.contains(tmp, lowerKey)) {
-                    tmp = (tmp as! String) + (separator as! String) + (lowerKey as! String)
-                    separator = ";"
+                if (!result.contains(lowerKey)) {
+                    result.append(lowerKey)
                 }
             }
         }
-        return DarabonbaString.Client.split(tmp, ";", nil)
+        return result
     }
 }

--- a/alibabacloud-gateway-pop/swift/Tests/AlibabacloudGatewayPOPTests/ClientTests.swift
+++ b/alibabacloud-gateway-pop/swift/Tests/AlibabacloudGatewayPOPTests/ClientTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import AlibabacloudGatewayPOP
+
+final class ClientTests: XCTestCase {
+    func testSignedHeadersKeepPrefixPairs() {
+        let client = Client()
+        let headers = [
+            "host": "example.com",
+            "x-acs-foobar": "bar",
+            "x-acs-foo": "foo",
+        ]
+
+        XCTAssertFalse(["x-acs-foobar"].contains("x-acs-foo"))
+        XCTAssertEqual(
+            client.getSignedHeaders(headers),
+            ["host", "x-acs-foo", "x-acs-foobar"]
+        )
+
+        let canonical = client.buildCanonicalizedHeaders(headers)
+        XCTAssertTrue(canonical.contains("host:example.com\n"))
+        XCTAssertTrue(canonical.contains("x-acs-foo:foo\n"))
+        XCTAssertTrue(canonical.contains("x-acs-foobar:bar\n"))
+    }
+}

--- a/alibabacloud-gateway-pop/ts/src/client.ts
+++ b/alibabacloud-gateway-pop/ts/src/client.ts
@@ -324,14 +324,12 @@ export default class Client extends SPI {
     // lower header key
     let headersArray : string[] = Map.keySet(headers);
     let newHeaders : {[key: string ]: string} = { };
-    let tmp : string = "";
 
     for (let key of headersArray) {
       let lowerKey = String.toLower(key);
       let value = headers[key];
       if (!Util.isUnset(value)) {
-        if (!String.contains(tmp, lowerKey) || String.equals(lowerKey, "host")) {
-          tmp = `${tmp},${lowerKey}`;
+        if (Util.isUnset(newHeaders[lowerKey]) || String.equals(lowerKey, "host")) {
           newHeaders[lowerKey] = String.trim(value);
         } else {
           newHeaders[lowerKey] = `${newHeaders[lowerKey]},${String.trim(value)}`;
@@ -362,20 +360,18 @@ export default class Client extends SPI {
 
     }
     let sortedHeadersArray = Array.ascSort(newHeadersArray);
-    let tmp : string = "";
-    let separator : string = "";
+    let result : string[] = [ ];
 
     for (let key of sortedHeadersArray) {
       if (String.hasPrefix(key, "x-acs-") || String.equals(key, "host") || String.equals(key, "content-type")) {
-        if (!String.contains(tmp, key)) {
-          tmp = `${tmp}${separator}${key}`;
-          separator = ";";
+        if (!Array.contains(result, key)) {
+          Array.append(result, key);
         }
 
       }
 
     }
-    return String.split(tmp, ";", null);
+    return result;
   }
 
 }

--- a/alibabacloud-gateway-pop/ts/test/client.spec.ts
+++ b/alibabacloud-gateway-pop/ts/test/client.spec.ts
@@ -1,6 +1,7 @@
 import Client from '../src/client';
 import assert from 'assert';
 import 'mocha';
+import Array from '@alicloud/darabonba-array';
 
 describe('Client', function () {
 
@@ -65,7 +66,11 @@ describe('Client', function () {
             'x-acs-foobar': '1',
             'x-acs-foo': '2'
         };
+        assert.strictEqual(false, Array.contains(['x-acs-foobar'], 'x-acs-foo'));
         assert.deepStrictEqual(['host', 'x-acs-foo', 'x-acs-foobar'], client.getSignedHeaders(headersPrefix));
+        const canonical = client.buildCanonicalizedHeaders(headersPrefix);
+        assert.ok(canonical.includes('x-acs-foo:2\n'));
+        assert.ok(canonical.includes('x-acs-foobar:1\n'));
 
         // 测试包含空值的headers情况
         const headers5 = {

--- a/alibabacloud-gateway-pop/ts/test/client.spec.ts
+++ b/alibabacloud-gateway-pop/ts/test/client.spec.ts
@@ -57,7 +57,15 @@ describe('Client', function () {
 
         // 测试空headers情况
         const headers4 = {};
-        assert.deepStrictEqual([''], client.getSignedHeaders(headers4));
+        assert.deepStrictEqual([], client.getSignedHeaders(headers4));
+
+        // Prefix pairs must not be mis-deduped via substring contains
+        const headersPrefix = {
+            'host': 'example.com',
+            'x-acs-foobar': '1',
+            'x-acs-foo': '2'
+        };
+        assert.deepStrictEqual(['host', 'x-acs-foo', 'x-acs-foobar'], client.getSignedHeaders(headersPrefix));
 
         // 测试包含空值的headers情况
         const headers5 = {


### PR DESCRIPTION
## Summary
- Replace `String.contains` substring dedup in `getSignedHeaders` / `buildCanonicalizedHeaders` with `Array.contains` (or map membership) in pop / pds / roa / fc.
- Prevents prefix false merges such as `x-acs-foo` vs `x-acs-foobar` corrupting canonical headers.
- Sync multi-language clients from `.tea`; add per-language unit coverage for Array.contains exact equality and the prefix case (Java / Python / TS / Go / C# / PHP / Swift).