### PR TITLE
fix(gateway-pds): V4 date from ISO8601 and set x-acs-date

### DIFF
--- a/alibabacloud-gateway-pds/csharp/core/Client.cs
+++ b/alibabacloud-gateway-pds/csharp/core/Client.cs
@@ -82,8 +82,11 @@ namespace AlibabaCloud.GatewayPds
                     }
                 }
             }
+            string dateTime = "";
             if (AlibabaCloud.DarabonbaString.StringUtil.Equals(signatureVersion, "v4"))
             {
+                dateTime = AlibabaCloud.OpenApiUtil.Client.GetTimestamp();
+                request.Headers["x-acs-date"] = dateTime;
                 if (AlibabaCloud.TeaUtil.Common.EqualString(signatureAlgorithm, "ACS4-HMAC-SM3"))
                 {
                     request.Headers["x-acs-content-sm3"] = hashedRequestPayload;
@@ -138,7 +141,8 @@ namespace AlibabaCloud.GatewayPds
                     }
                     if (AlibabaCloud.DarabonbaString.StringUtil.Equals(signatureVersion, "v4"))
                     {
-                        string dateNew = AlibabaCloud.DarabonbaString.StringUtil.SubString(date, 0, 10);
+                        string dateNew = AlibabaCloud.DarabonbaString.StringUtil.SubString(dateTime, 0, 10);
+                        dateNew = AlibabaCloud.DarabonbaString.StringUtil.Replace(dateNew, "-", "", null);
                         string region = GetRegion(config.Endpoint);
                         byte[] signingkey = GetSigningkey(signatureAlgorithm, accessKeySecret, region, dateNew);
                         request.Headers["Authorization"] = GetAuthorizationV4(request.Pathname, request.Method, request.Query, headers, signatureAlgorithm, hashedRequestPayload, accessKeyId, signingkey, request.ProductId, region, dateNew);
@@ -201,8 +205,11 @@ namespace AlibabaCloud.GatewayPds
                     }
                 }
             }
+            string dateTime = "";
             if (AlibabaCloud.DarabonbaString.StringUtil.Equals(signatureVersion, "v4"))
             {
+                dateTime = AlibabaCloud.OpenApiUtil.Client.GetTimestamp();
+                request.Headers["x-acs-date"] = dateTime;
                 if (AlibabaCloud.TeaUtil.Common.EqualString(signatureAlgorithm, "ACS4-HMAC-SM3"))
                 {
                     request.Headers["x-acs-content-sm3"] = hashedRequestPayload;
@@ -257,7 +264,8 @@ namespace AlibabaCloud.GatewayPds
                     }
                     if (AlibabaCloud.DarabonbaString.StringUtil.Equals(signatureVersion, "v4"))
                     {
-                        string dateNew = AlibabaCloud.DarabonbaString.StringUtil.SubString(date, 0, 10);
+                        string dateNew = AlibabaCloud.DarabonbaString.StringUtil.SubString(dateTime, 0, 10);
+                        dateNew = AlibabaCloud.DarabonbaString.StringUtil.Replace(dateNew, "-", "", null);
                         string region = GetRegion(config.Endpoint);
                         byte[] signingkey = await GetSigningkeyAsync(signatureAlgorithm, accessKeySecret, region, dateNew);
                         request.Headers["Authorization"] = await GetAuthorizationV4Async(request.Pathname, request.Method, request.Query, headers, signatureAlgorithm, hashedRequestPayload, accessKeyId, signingkey, request.ProductId, region, dateNew);

--- a/alibabacloud-gateway-pds/golang/client/client.go
+++ b/alibabacloud-gateway-pds/golang/client/client.go
@@ -89,7 +89,10 @@ func (client *Client) ModifyRequest(context *spi.InterceptorContext, attributeMa
 
 	}
 
+	dateTime := tea.String("")
 	if tea.BoolValue(string_.Equals(signatureVersion, tea.String("v4"))) {
+		dateTime = openapiutil.GetTimestamp()
+		request.Headers["x-acs-date"] = dateTime
 		if tea.BoolValue(util.EqualString(signatureAlgorithm, tea.String("ACS4-HMAC-SM3"))) {
 			request.Headers["x-acs-content-sm3"] = hashedRequestPayload
 		} else {
@@ -135,7 +138,8 @@ func (client *Client) ModifyRequest(context *spi.InterceptorContext, attributeMa
 			}
 
 			if tea.BoolValue(string_.Equals(signatureVersion, tea.String("v4"))) {
-				dateNew := string_.SubString(date, tea.Int(0), tea.Int(10))
+				dateNew := string_.SubString(dateTime, tea.Int(0), tea.Int(10))
+				dateNew = string_.Replace(dateNew, tea.String("-"), tea.String(""), nil)
 				region := client.GetRegion(config.Endpoint)
 				signingkey, _err := client.GetSigningkey(signatureAlgorithm, accessKeySecret, region, dateNew)
 				if _err != nil {

--- a/alibabacloud-gateway-pds/java/pom.xml
+++ b/alibabacloud-gateway-pds/java/pom.xml
@@ -96,6 +96,12 @@
       <artifactId>tea</artifactId>
       <version>[1.1.14, 2.0.0)</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/alibabacloud-gateway-pds/java/src/main/java/com/aliyun/gateway/pds/Client.java
+++ b/alibabacloud-gateway-pds/java/src/main/java/com/aliyun/gateway/pds/Client.java
@@ -58,7 +58,10 @@ public class Client extends com.aliyun.gateway.spi.Client {
 
         }
 
+        String dateTime = "";
         if (com.aliyun.darabonbastring.Client.equals(signatureVersion, "v4")) {
+            dateTime = com.aliyun.openapiutil.Client.getTimestamp();
+            request.headers.put("x-acs-date", dateTime);
             if (com.aliyun.teautil.Common.equalString(signatureAlgorithm, "ACS4-HMAC-SM3")) {
                 request.headers.put("x-acs-content-sm3", hashedRequestPayload);
             } else {
@@ -100,7 +103,8 @@ public class Client extends com.aliyun.gateway.spi.Client {
                 }
 
                 if (com.aliyun.darabonbastring.Client.equals(signatureVersion, "v4")) {
-                    String dateNew = com.aliyun.darabonbastring.Client.subString(date, 0, 10);
+                    String dateNew = com.aliyun.darabonbastring.Client.subString(dateTime, 0, 10);
+                    dateNew = com.aliyun.darabonbastring.Client.replace(dateNew, "-", "", null);
                     String region = this.getRegion(config.endpoint);
                     byte[] signingkey = this.getSigningkey(signatureAlgorithm, accessKeySecret, region, dateNew);
                     request.headers.put("Authorization", this.getAuthorizationV4(request.pathname, request.method, request.query, headers, signatureAlgorithm, hashedRequestPayload, accessKeyId, signingkey, request.productId, region, dateNew));

--- a/alibabacloud-gateway-pds/java/src/test/java/com/aliyun/gateway/pds/UnitTest.java
+++ b/alibabacloud-gateway-pds/java/src/test/java/com/aliyun/gateway/pds/UnitTest.java
@@ -1,0 +1,79 @@
+package com.aliyun.gateway.pds;
+
+import java.util.HashMap;
+import java.util.regex.Pattern;
+
+import com.aliyun.credentials.models.Config;
+import com.aliyun.gateway.spi.models.AttributeMap;
+import com.aliyun.gateway.spi.models.InterceptorContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UnitTest {
+
+    private static final Pattern ISO8601 = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$");
+    private static final Pattern YYYYMMDD = Pattern.compile("^\\d{8}$");
+
+    @Test
+    public void getRegionTest() throws Exception {
+        Client client = new Client();
+        Assert.assertEquals("center", client.getRegion(null));
+        Assert.assertEquals("center", client.getRegion(""));
+        Assert.assertEquals("center", client.getRegion("api.aliyunpds.com"));
+        Assert.assertEquals("cn-hangzhou", client.getRegion("cn-hangzhou.admin.aliyunpds.com"));
+    }
+
+    @Test
+    public void modifyRequestV4UsesIsoDateNotRfc1123() throws Exception {
+        Client client = new Client();
+
+        Config credConfig = new Config();
+        credConfig.type = "access_key";
+        credConfig.accessKeyId = "ak";
+        credConfig.accessKeySecret = "sk";
+        com.aliyun.credentials.Client credential = new com.aliyun.credentials.Client(credConfig);
+
+        InterceptorContext.InterceptorContextRequest request = new InterceptorContext.InterceptorContextRequest();
+        request.headers = new HashMap<String, String>();
+        request.query = new HashMap<String, String>();
+        request.pathname = "/v2/file/get";
+        request.productId = "pds";
+        request.action = "GetFile";
+        request.version = "2022-03-01";
+        request.protocol = "HTTPS";
+        request.method = "POST";
+        request.authType = "AK";
+        request.bodyType = "json";
+        request.reqBodyType = "json";
+        request.userAgent = "UnitTest";
+        request.signatureVersion = "v4";
+        request.signatureAlgorithm = "ACS4-HMAC-SHA256";
+        request.credential = credential;
+
+        InterceptorContext.InterceptorContextConfiguration configuration =
+            new InterceptorContext.InterceptorContextConfiguration();
+        configuration.endpoint = "api.aliyunpds.com";
+
+        InterceptorContext context = new InterceptorContext();
+        context.request = request;
+        context.configuration = configuration;
+        context.response = new InterceptorContext.InterceptorContextResponse();
+
+        client.modifyRequest(context, new AttributeMap());
+
+        String acsDate = request.headers.get("x-acs-date");
+        Assert.assertNotNull("V4 must set x-acs-date", acsDate);
+        Assert.assertTrue("x-acs-date must be ISO8601, got: " + acsDate, ISO8601.matcher(acsDate).matches());
+
+        String authorization = request.headers.get("Authorization");
+        Assert.assertNotNull(authorization);
+        Assert.assertTrue(authorization.startsWith("ACS4-HMAC-SHA256 Credential=ak/"));
+
+        String credentialScopeDate = authorization.substring("ACS4-HMAC-SHA256 Credential=ak/".length(),
+            "ACS4-HMAC-SHA256 Credential=ak/".length() + 8);
+        Assert.assertTrue("credential scope date must be yyyyMMdd, got: " + credentialScopeDate,
+            YYYYMMDD.matcher(credentialScopeDate).matches());
+        Assert.assertFalse("must not slice RFC1123 Date header", credentialScopeDate.contains(","));
+        Assert.assertEquals(acsDate.substring(0, 10).replace("-", ""), credentialScopeDate);
+    }
+}

--- a/alibabacloud-gateway-pds/main.tea
+++ b/alibabacloud-gateway-pds/main.tea
@@ -60,7 +60,12 @@ async function modifyRequest(context: SPI.InterceptorContext, attributeMap: SPI.
     }
   }
 
+  // V4 credential scope needs yyyyMMdd from ISO8601 (OpenApiUtil.getTimestamp),
+  // not RFC1123 Date header (Util.getDateUTCString). Align with gateway-pop.
+  var dateTime = '';
   if (String.equals(signatureVersion, 'v4')){
+    dateTime = OpenApiUtil.getTimestamp();
+    request.headers.x-acs-date = dateTime;
     if (Util.equalString(signatureAlgorithm, 'ACS4-HMAC-SM3')) {
       request.headers.x-acs-content-sm3 = hashedRequestPayload;
     } else {
@@ -100,7 +105,8 @@ async function modifyRequest(context: SPI.InterceptorContext, attributeMap: SPI.
           headers = request.headers;
       }
       if (String.equals(signatureVersion, 'v4')) {
-        var dateNew = String.subString(date, 0, 10);
+        var dateNew = String.subString(dateTime, 0, 10);
+        dateNew = String.replace(dateNew, '-', '', null);
         var region = getRegion(config.endpoint);
         var signingkey = getSigningkey(signatureAlgorithm, accessKeySecret, region, dateNew);
         request.headers.Authorization = getAuthorizationV4(request.pathname, request.method, request.query, headers, signatureAlgorithm, hashedRequestPayload, accessKeyId, signingkey, request.productId, region, dateNew);

--- a/alibabacloud-gateway-pds/php/src/Client.php
+++ b/alibabacloud-gateway-pds/php/src/Client.php
@@ -78,7 +78,10 @@ class Client extends DarabonbaGatewaySpiClient
                 }
             }
         }
+        $dateTime = "";
         if (StringUtil::equals($signatureVersion, "v4")) {
+            $dateTime = OpenApiUtilClient::getTimestamp();
+            $request->headers["x-acs-date"] = $dateTime;
             if (Utils::equalString($signatureAlgorithm, "ACS4-HMAC-SM3")) {
                 $request->headers["x-acs-content-sm3"] = $hashedRequestPayload;
             } else {
@@ -116,7 +119,8 @@ class Client extends DarabonbaGatewaySpiClient
                     $headers = $request->headers;
                 }
                 if (StringUtil::equals($signatureVersion, "v4")) {
-                    $dateNew = StringUtil::subString($date, 0, 10);
+                    $dateNew = StringUtil::subString($dateTime, 0, 10);
+                    $dateNew = StringUtil::replace($dateNew, "-", "", null);
                     $region = $this->getRegion($config->endpoint);
                     $signingkey = $this->getSigningkey($signatureAlgorithm, $accessKeySecret, $region, $dateNew);
                     $request->headers["Authorization"] = $this->getAuthorizationV4($request->pathname, $request->method, $request->query, $headers, $signatureAlgorithm, $hashedRequestPayload, $accessKeyId, $signingkey, $request->productId, $region, $dateNew);

--- a/alibabacloud-gateway-pds/python/alibabacloud_gateway_pds/client.py
+++ b/alibabacloud-gateway-pds/python/alibabacloud_gateway_pds/client.py
@@ -73,7 +73,10 @@ class Client(SPIClient):
                     hashed_request_payload = Encoder.hex_encode(Encoder.hash(UtilClient.to_bytes(form_obj), signature_algorithm))
                     request.stream = form_obj
                     request.headers['content-type'] = 'application/x-www-form-urlencoded'
+        date_time = ''
         if StringClient.equals(signature_version, 'v4'):
+            date_time = OpenApiUtilClient.get_timestamp()
+            request.headers['x-acs-date'] = date_time
             if UtilClient.equal_string(signature_algorithm, 'ACS4-HMAC-SM3'):
                 request.headers['x-acs-content-sm3'] = hashed_request_payload
             else:
@@ -106,7 +109,8 @@ class Client(SPIClient):
                 else:
                     headers = request.headers
                 if StringClient.equals(signature_version, 'v4'):
-                    date_new = StringClient.sub_string(date, 0, 10)
+                    date_new = StringClient.sub_string(date_time, 0, 10)
+                    date_new = StringClient.replace(date_new, '-', '', None)
                     region = self.get_region(config.endpoint)
                     signingkey = self.get_signingkey(signature_algorithm, access_key_secret, region, date_new)
                     request.headers['Authorization'] = self.get_authorization_v4(request.pathname, request.method, request.query, headers, signature_algorithm, hashed_request_payload, access_key_id, signingkey, request.product_id, region, date_new)
@@ -151,7 +155,10 @@ class Client(SPIClient):
                     hashed_request_payload = Encoder.hex_encode(Encoder.hash(UtilClient.to_bytes(form_obj), signature_algorithm))
                     request.stream = form_obj
                     request.headers['content-type'] = 'application/x-www-form-urlencoded'
+        date_time = ''
         if StringClient.equals(signature_version, 'v4'):
+            date_time = OpenApiUtilClient.get_timestamp()
+            request.headers['x-acs-date'] = date_time
             if UtilClient.equal_string(signature_algorithm, 'ACS4-HMAC-SM3'):
                 request.headers['x-acs-content-sm3'] = hashed_request_payload
             else:
@@ -184,7 +191,8 @@ class Client(SPIClient):
                 else:
                     headers = request.headers
                 if StringClient.equals(signature_version, 'v4'):
-                    date_new = StringClient.sub_string(date, 0, 10)
+                    date_new = StringClient.sub_string(date_time, 0, 10)
+                    date_new = StringClient.replace(date_new, '-', '', None)
                     region = self.get_region(config.endpoint)
                     signingkey = await self.get_signingkey_async(signature_algorithm, access_key_secret, region, date_new)
                     request.headers['Authorization'] = await self.get_authorization_v4_async(request.pathname, request.method, request.query, headers, signature_algorithm, hashed_request_payload, access_key_id, signingkey, request.product_id, region, date_new)

--- a/alibabacloud-gateway-pds/ts/src/client.ts
+++ b/alibabacloud-gateway-pds/ts/src/client.ts
@@ -64,7 +64,10 @@ export default class Client extends SPI {
 
     }
 
+    let dateTime = "";
     if (String.equals(signatureVersion, "v4")) {
+      dateTime = OpenApiUtil.getTimestamp();
+      request.headers["x-acs-date"] = dateTime;
       if (Util.equalString(signatureAlgorithm, "ACS4-HMAC-SM3")) {
         request.headers["x-acs-content-sm3"] = hashedRequestPayload;
       } else {
@@ -107,7 +110,8 @@ export default class Client extends SPI {
         }
 
         if (String.equals(signatureVersion, "v4")) {
-          let dateNew = String.subString(date, 0, 10);
+          let dateNew = String.subString(dateTime, 0, 10);
+          dateNew = String.replace(dateNew, "-", "", null);
           let region = this.getRegion(config.endpoint);
           let signingkey = await this.getSigningkey(signatureAlgorithm, accessKeySecret, region, dateNew);
           request.headers["Authorization"] = await this.getAuthorizationV4(request.pathname, request.method, request.query, headers, signatureAlgorithm, hashedRequestPayload, accessKeyId, signingkey, request.productId, region, dateNew);


### PR DESCRIPTION
## Summary
- V4 signing date now comes from `OpenApiUtil.getTimestamp()` (yyyyMMdd after strip), not RFC1123 `Date` substring
- Set `x-acs-date` on V4 path, aligned with gateway-pop
- Synced Java/Go/TS/Python/PHP/C# clients; added Java UnitTest for credential-scope date format