### PR TITLE
fix(gateway-oss): parse region from dual-stack endpoint

### DIFF
--- a/alibabacloud-gateway-oss/csharp/core/Client.cs
+++ b/alibabacloud-gateway-oss/csharp/core/Client.cs
@@ -673,6 +673,12 @@ namespace AlibabaCloud.GatewayOss
                     idx = AlibabaCloud.DarabonbaString.StringUtil.Index(endpoint, ".aliyuncs.com");
                     return AlibabaCloud.DarabonbaString.StringUtil.SubString(endpoint, 4, idx);
                 }
+                // dual-stack / ipv6: {region}.oss.aliyuncs.com
+                if (AlibabaCloud.DarabonbaString.StringUtil.HasSuffix(endpoint, ".oss.aliyuncs.com"))
+                {
+                    idx = AlibabaCloud.DarabonbaString.StringUtil.Index(endpoint, ".oss.aliyuncs.com");
+                    return AlibabaCloud.DarabonbaString.StringUtil.SubString(endpoint, 0, idx);
+                }
                 if (AlibabaCloud.DarabonbaString.StringUtil.HasSuffix(endpoint, ".mgw.aliyuncs.com"))
                 {
                     idx = AlibabaCloud.DarabonbaString.StringUtil.Index(endpoint, ".mgw.aliyuncs.com");
@@ -706,6 +712,12 @@ namespace AlibabaCloud.GatewayOss
                 {
                     idx = AlibabaCloud.DarabonbaString.StringUtil.Index(endpoint, ".aliyuncs.com");
                     return AlibabaCloud.DarabonbaString.StringUtil.SubString(endpoint, 4, idx);
+                }
+                // dual-stack / ipv6: {region}.oss.aliyuncs.com
+                if (AlibabaCloud.DarabonbaString.StringUtil.HasSuffix(endpoint, ".oss.aliyuncs.com"))
+                {
+                    idx = AlibabaCloud.DarabonbaString.StringUtil.Index(endpoint, ".oss.aliyuncs.com");
+                    return AlibabaCloud.DarabonbaString.StringUtil.SubString(endpoint, 0, idx);
                 }
                 if (AlibabaCloud.DarabonbaString.StringUtil.HasSuffix(endpoint, ".mgw.aliyuncs.com"))
                 {

--- a/alibabacloud-gateway-oss/golang/client/client.go
+++ b/alibabacloud-gateway-oss/golang/client/client.go
@@ -368,6 +368,14 @@ func (client *Client) GetRegionIdFromEndpoint (endpoint *string) (_result *strin
       return _result, _err
     }
 
+    // dual-stack / ipv6: {region}.oss.aliyuncs.com
+    if tea.BoolValue(string_.HasSuffix(endpoint, tea.String(".oss.aliyuncs.com"))) {
+      idx = string_.Index(endpoint, tea.String(".oss.aliyuncs.com"))
+      _body := string_.SubString(endpoint, tea.Int(0), idx)
+      _result = _body
+      return _result, _err
+    }
+
     if tea.BoolValue(string_.HasSuffix(endpoint, tea.String(".mgw.aliyuncs.com"))) {
       idx = string_.Index(endpoint, tea.String(".mgw.aliyuncs.com"))
       _body := string_.SubString(endpoint, tea.Int(0), idx)

--- a/alibabacloud-gateway-oss/java/src/main/java/com/aliyun/gateway/oss/Client.java
+++ b/alibabacloud-gateway-oss/java/src/main/java/com/aliyun/gateway/oss/Client.java
@@ -355,6 +355,12 @@ public class Client extends com.aliyun.gateway.spi.Client {
                 return com.aliyun.darabonbastring.Client.subString(endpoint, 4, idx);
             }
 
+            // dual-stack / ipv6: {region}.oss.aliyuncs.com
+            if (com.aliyun.darabonbastring.Client.hasSuffix(endpoint, ".oss.aliyuncs.com")) {
+                idx = com.aliyun.darabonbastring.Client.index(endpoint, ".oss.aliyuncs.com");
+                return com.aliyun.darabonbastring.Client.subString(endpoint, 0, idx);
+            }
+
             if (com.aliyun.darabonbastring.Client.hasSuffix(endpoint, ".mgw.aliyuncs.com")) {
                 idx = com.aliyun.darabonbastring.Client.index(endpoint, ".mgw.aliyuncs.com");
                 return com.aliyun.darabonbastring.Client.subString(endpoint, 0, idx);

--- a/alibabacloud-gateway-oss/java/src/test/java/com/aliyun/gateway/oss/UnitTest.java
+++ b/alibabacloud-gateway-oss/java/src/test/java/com/aliyun/gateway/oss/UnitTest.java
@@ -126,4 +126,31 @@ public class UnitTest {
 
         Assert.assertEquals("?acl&versionId=123", client.buildCanonicalizedQueryStringV2(query));
     }
+
+    @Test
+    public void getRegionIdFromEndpointTest() throws Exception {
+        Client client = new Client();
+
+        // classic: oss-{region}.aliyuncs.com
+        Assert.assertEquals("cn-hangzhou",
+            client.getRegionIdFromEndpoint("oss-cn-hangzhou.aliyuncs.com"));
+        Assert.assertEquals("cn-shanghai",
+            client.getRegionIdFromEndpoint("oss-cn-shanghai.aliyuncs.com"));
+
+        // dual-stack / ipv6: {region}.oss.aliyuncs.com
+        Assert.assertEquals("cn-hangzhou",
+            client.getRegionIdFromEndpoint("cn-hangzhou.oss.aliyuncs.com"));
+        Assert.assertEquals("cn-shanghai",
+            client.getRegionIdFromEndpoint("cn-shanghai.oss.aliyuncs.com"));
+        Assert.assertEquals("ap-southeast-1",
+            client.getRegionIdFromEndpoint("ap-southeast-1.oss.aliyuncs.com"));
+
+        // fallback
+        Assert.assertEquals("cn-hangzhou",
+            client.getRegionIdFromEndpoint(null));
+        Assert.assertEquals("cn-hangzhou",
+            client.getRegionIdFromEndpoint(""));
+        Assert.assertEquals("cn-hangzhou",
+            client.getRegionIdFromEndpoint("custom.endpoint.com"));
+    }
 }

--- a/alibabacloud-gateway-oss/main.tea
+++ b/alibabacloud-gateway-oss/main.tea
@@ -249,6 +249,11 @@ async function getRegionIdFromEndpoint(endpoint: string) : string {
       idx = String.index(endpoint, '.aliyuncs.com');
       return String.subString(endpoint, 4, idx);
     }
+    // dual-stack / ipv6: {region}.oss.aliyuncs.com
+    if (String.hasSuffix(endpoint, '.oss.aliyuncs.com')) {
+      idx = String.index(endpoint, '.oss.aliyuncs.com');
+      return String.subString(endpoint, 0, idx);
+    }
     if (String.hasSuffix(endpoint, '.mgw.aliyuncs.com')) {
       idx = String.index(endpoint, '.mgw.aliyuncs.com');
       return String.subString(endpoint, 0, idx);

--- a/alibabacloud-gateway-oss/php/src/Client.php
+++ b/alibabacloud-gateway-oss/php/src/Client.php
@@ -383,6 +383,11 @@ class Client extends DarabonbaGatewaySpiClient {
                 $idx = StringUtil::index($endpoint, ".aliyuncs.com");
                 return StringUtil::subString($endpoint, 4, $idx);
             }
+            // dual-stack / ipv6: {region}.oss.aliyuncs.com
+            if (StringUtil::hasSuffix($endpoint, ".oss.aliyuncs.com")) {
+                $idx = StringUtil::index($endpoint, ".oss.aliyuncs.com");
+                return StringUtil::subString($endpoint, 0, $idx);
+            }
             if (StringUtil::hasSuffix($endpoint, ".mgw.aliyuncs.com")) {
                 $idx = StringUtil::index($endpoint, ".mgw.aliyuncs.com");
                 return StringUtil::subString($endpoint, 0, $idx);

--- a/alibabacloud-gateway-oss/python/alibabacloud_gateway_oss/client.py
+++ b/alibabacloud-gateway-oss/python/alibabacloud_gateway_oss/client.py
@@ -504,6 +504,10 @@ class Client(SPIClient):
             if StringClient.has_prefix(endpoint, 'oss-') and StringClient.has_suffix(endpoint, '.aliyuncs.com'):
                 idx = StringClient.index(endpoint, '.aliyuncs.com')
                 return StringClient.sub_string(endpoint, 4, idx)
+            # dual-stack / ipv6: {region}.oss.aliyuncs.com
+            if StringClient.has_suffix(endpoint, '.oss.aliyuncs.com'):
+                idx = StringClient.index(endpoint, '.oss.aliyuncs.com')
+                return StringClient.sub_string(endpoint, 0, idx)
             if StringClient.has_suffix(endpoint, '.mgw.aliyuncs.com'):
                 idx = StringClient.index(endpoint, '.mgw.aliyuncs.com')
                 return StringClient.sub_string(endpoint, 0, idx)
@@ -527,6 +531,10 @@ class Client(SPIClient):
             if StringClient.has_prefix(endpoint, 'oss-') and StringClient.has_suffix(endpoint, '.aliyuncs.com'):
                 idx = StringClient.index(endpoint, '.aliyuncs.com')
                 return StringClient.sub_string(endpoint, 4, idx)
+            # dual-stack / ipv6: {region}.oss.aliyuncs.com
+            if StringClient.has_suffix(endpoint, '.oss.aliyuncs.com'):
+                idx = StringClient.index(endpoint, '.oss.aliyuncs.com')
+                return StringClient.sub_string(endpoint, 0, idx)
             if StringClient.has_suffix(endpoint, '.mgw.aliyuncs.com'):
                 idx = StringClient.index(endpoint, '.mgw.aliyuncs.com')
                 return StringClient.sub_string(endpoint, 0, idx)

--- a/alibabacloud-gateway-oss/python2/alibabacloud_gateway_oss/client.py
+++ b/alibabacloud-gateway-oss/python2/alibabacloud_gateway_oss/client.py
@@ -317,6 +317,10 @@ class Client(SPIClient):
             if StringClient.has_prefix(endpoint, 'oss-') and StringClient.has_suffix(endpoint, '.aliyuncs.com'):
                 idx = StringClient.index(endpoint, '.aliyuncs.com')
                 return StringClient.sub_string(endpoint, 4, idx)
+            # dual-stack / ipv6: {region}.oss.aliyuncs.com
+            if StringClient.has_suffix(endpoint, '.oss.aliyuncs.com'):
+                idx = StringClient.index(endpoint, '.oss.aliyuncs.com')
+                return StringClient.sub_string(endpoint, 0, idx)
             if StringClient.has_suffix(endpoint, '.mgw.aliyuncs.com'):
                 idx = StringClient.index(endpoint, '.mgw.aliyuncs.com')
                 return StringClient.sub_string(endpoint, 0, idx)

--- a/alibabacloud-gateway-oss/ts/src/client.ts
+++ b/alibabacloud-gateway-oss/ts/src/client.ts
@@ -338,6 +338,11 @@ export default class Client extends SPI {
         let idx = String.index(endpoint, ".aliyuncs.com");
         return String.subString(endpoint, 4, idx);
       }
+      // dual-stack / ipv6: {region}.oss.aliyuncs.com
+      if (String.hasSuffix(endpoint, ".oss.aliyuncs.com")) {
+        let idx = String.index(endpoint, ".oss.aliyuncs.com");
+        return String.subString(endpoint, 0, idx);
+      }
 
       if (String.hasSuffix(endpoint, ".mgw.aliyuncs.com")) {
         let idx = String.index(endpoint, ".mgw.aliyuncs.com");


### PR DESCRIPTION
## Summary
- `getRegionIdFromEndpoint` now recognizes dual-stack `{region}.oss.aliyuncs.com` (complements IPv6 endpoint construction).
- Synced Java/Go/TS/Python/Python2/PHP/C#; Java unit tests cover classic + dual-stack + fallback.
- Avoids wrong V4 credential scope falling back to `cn-hangzhou` when regionId is unset.